### PR TITLE
Remove language support for portal texts

### DIFF
--- a/Intranet/Controllers/PortalTextsController.cs
+++ b/Intranet/Controllers/PortalTextsController.cs
@@ -44,7 +44,7 @@ public class PortalTextsController : Controller
     // POST: PortalTexts/Create
     [HttpPost]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Create([Bind("Key,Value,Section,Language")] PortalText text)
+    public async Task<IActionResult> Create([Bind("Key,Value,Section")] PortalText text)
     {
         if (ModelState.IsValid)
         {
@@ -66,7 +66,7 @@ public class PortalTextsController : Controller
     // POST: PortalTexts/Edit/5
     [HttpPost]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Edit(int id, [Bind("Id,Key,Value,Section,Language")] PortalText text)
+    public async Task<IActionResult> Edit(int id, [Bind("Id,Key,Value,Section")] PortalText text)
     {
         if (id != text.Id) return BadRequest();
 

--- a/Intranet/Models/IntranetContext.cs
+++ b/Intranet/Models/IntranetContext.cs
@@ -130,7 +130,7 @@ public partial class IntranetContext : DbContext
         {
             entity.Property(e => e.Section)
                   .HasMaxLength(100);
-            entity.HasIndex(e => new { e.Key, e.Language }).IsUnique();
+            entity.HasIndex(e => new { e.Key, e.Section }).IsUnique();
         });
 
         OnModelCreatingPartial(modelBuilder);

--- a/Intranet/Models/PortalText.cs
+++ b/Intranet/Models/PortalText.cs
@@ -17,7 +17,4 @@ public class PortalText
 
     [StringLength(100)]
     public string Section { get; set; } = string.Empty;
-
-    [StringLength(10)]
-    public string? Language { get; set; }
 }

--- a/Intranet/Views/PortalTexts/Create.cshtml
+++ b/Intranet/Views/PortalTexts/Create.cshtml
@@ -19,11 +19,6 @@
         <input asp-for="Section" class="form-control" />
         <span asp-validation-for="Section" class="text-danger"></span>
     </div>
-    <div class="mb-3">
-        <label asp-for="Language" class="form-label"></label>
-        <input asp-for="Language" class="form-control" />
-        <span asp-validation-for="Language" class="text-danger"></span>
-    </div>
     <button type="submit" class="btn btn-primary">Save</button>
     <a asp-action="Index" class="btn btn-secondary">Back</a>
 </form>

--- a/Intranet/Views/PortalTexts/Edit.cshtml
+++ b/Intranet/Views/PortalTexts/Edit.cshtml
@@ -20,11 +20,6 @@
         <input asp-for="Section" class="form-control" />
         <span asp-validation-for="Section" class="text-danger"></span>
     </div>
-    <div class="mb-3">
-        <label asp-for="Language" class="form-label"></label>
-        <input asp-for="Language" class="form-control" />
-        <span asp-validation-for="Language" class="text-danger"></span>
-    </div>
     <button type="submit" class="btn btn-primary">Save</button>
     <a asp-action="Index" class="btn btn-secondary">Back</a>
 </form>

--- a/Intranet/Views/PortalTexts/Index.cshtml
+++ b/Intranet/Views/PortalTexts/Index.cshtml
@@ -19,7 +19,6 @@
             <th>Key</th>
             <th>Value</th>
             <th>Section</th>
-            <th>Language</th>
             <th></th>
         </tr>
     </thead>
@@ -30,7 +29,6 @@
             <td>@item.Key</td>
             <td>@item.Value</td>
             <td>@item.Section</td>
-            <td>@item.Language</td>
             <td>
                 <a asp-action="Edit" asp-route-id="@item.Id">Edit</a> |
                 <a asp-action="Delete" asp-route-id="@item.Id">Delete</a>

--- a/Portal/Services/PortalTextService.cs
+++ b/Portal/Services/PortalTextService.cs
@@ -15,14 +15,14 @@ public class PortalTextService
         _cache = cache;
     }
 
-    public string Get(string key, string? lang = null)
+    public string Get(string key)
     {
-        var cacheKey = $"PortalText-{key}-{lang}";
+        var cacheKey = $"PortalText-{key}";
         if (!_cache.TryGetValue(cacheKey, out string? value))
         {
             var text = _context.PortalTexts
                 .AsNoTracking()
-                .FirstOrDefault(t => t.Key == key && t.Language == lang);
+                .FirstOrDefault(t => t.Key == key);
             value = text?.Value ?? key;
             _cache.Set(cacheKey, value, TimeSpan.FromMinutes(10));
         }

--- a/sql/AddPortalTextSection.sql
+++ b/sql/AddPortalTextSection.sql
@@ -1,0 +1,13 @@
+IF EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_PortalTexts_Key_Language')
+    DROP INDEX IX_PortalTexts_Key_Language ON PortalTexts;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.columns
+    WHERE Name = N'Section' AND Object_ID = Object_ID(N'PortalTexts')
+)
+BEGIN
+    ALTER TABLE PortalTexts ADD Section NVARCHAR(100) NOT NULL DEFAULT '';
+END
+
+CREATE UNIQUE INDEX IX_PortalTexts_Key_Section ON PortalTexts(Key, Section);
+GO


### PR DESCRIPTION
## Summary
- stop using `Language` field for portal texts
- reference `Section` column in `PortalText` entity
- update portal text controller/views for new model
- add SQL helper to create `Section` column and index
- cache portal texts by key only

## Testing
- `dotnet build Firma.sln -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684178c0746483308df448c6a95358ff