### PR TITLE
Add portal text helper and dynamic categories

### DIFF
--- a/Intranet/Controllers/PortalTextsController.cs
+++ b/Intranet/Controllers/PortalTextsController.cs
@@ -15,6 +15,17 @@ public class PortalTextsController : Controller
         _context = context;
     }
 
+    // GET: PortalTexts/Sections
+    public async Task<IActionResult> Sections()
+    {
+        var sections = await _context.PortalTexts
+            .GroupBy(t => t.Section)
+            .Select(g => new SectionViewModel { Name = g.Key, Count = g.Count() })
+            .OrderBy(s => s.Name)
+            .ToListAsync();
+        return View(sections);
+    }
+
     // GET: PortalTexts
     public async Task<IActionResult> Index(string? section)
     {

--- a/Intranet/Models/SectionViewModel.cs
+++ b/Intranet/Models/SectionViewModel.cs
@@ -1,0 +1,7 @@
+namespace Intranet.Models;
+
+public class SectionViewModel
+{
+    public string Name { get; set; } = string.Empty;
+    public int Count { get; set; }
+}

--- a/Intranet/Views/Home/Index.cshtml
+++ b/Intranet/Views/Home/Index.cshtml
@@ -41,7 +41,7 @@
             <span class="badge bg-primary me-2">Sklep: Warszawa&nbsp;Centrum</span>
             @if (User.IsInRole("Admin"))
             {
-                <a asp-controller="PortalTexts" asp-action="Index" class="btn btn-sm btn-dark me-2">
+                <a asp-controller="PortalTexts" asp-action="Sections" class="btn btn-sm btn-dark me-2">
                     <i class="bi bi-pencil-square"></i> Teksty
                 </a>
             }

--- a/Intranet/Views/PortalTexts/Sections.cshtml
+++ b/Intranet/Views/PortalTexts/Sections.cshtml
@@ -1,0 +1,27 @@
+@model IEnumerable<Intranet.Models.SectionViewModel>
+@{
+    ViewData["Title"] = "Sekcje tekstów";
+}
+<h1>@ViewData["Title"]</h1>
+<table class="table">
+    <thead>
+    <tr>
+        <th>Nazwa sekcji</th>
+        <th>Liczba tekstów</th>
+        <th></th>
+    </tr>
+    </thead>
+    <tbody>
+    @foreach (var item in Model)
+    {
+        <tr>
+            <td>@item.Name</td>
+            <td>@item.Count</td>
+            <td>
+                <a asp-action="Index" asp-route-section="@item.Name">Pokaż teksty</a>
+            </td>
+        </tr>
+    }
+    </tbody>
+</table>
+<a asp-action="Index" class="btn btn-secondary">Wszystkie teksty</a>

--- a/Portal/TagHelpers/PortalTextTagHelper.cs
+++ b/Portal/TagHelpers/PortalTextTagHelper.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Portal.Services;
+
+namespace Portal.TagHelpers;
+
+[HtmlTargetElement("*", Attributes = "portal-text")]
+public class PortalTextTagHelper : TagHelper
+{
+    private readonly PortalTextService _service;
+
+    public PortalTextTagHelper(PortalTextService service)
+    {
+        _service = service;
+    }
+
+    [HtmlAttributeName("portal-text")]
+    public string Key { get; set; } = string.Empty;
+
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        var value = _service.Get(Key);
+        output.Content.SetContent(value);
+    }
+}

--- a/Portal/Views/Account/Login.cshtml
+++ b/Portal/Views/Account/Login.cshtml
@@ -1,18 +1,18 @@
 @{
-    ViewData["Title"] = "Logowanie";
+    ViewData["Title"] = PortalTextService.Get("Account_Login_Title");
 }
 <div class="py-16 px-6 md:px-12 lg:px-24">
     <div class="max-w-md mx-auto bg-white p-6 shadow">
         <form method="post">
             <div class="mb-4">
-                <label class="block mb-1">Email</label>
+                <label class="block mb-1" portal-text="Account_Login_Email"></label>
                 <input type="email" name="email" class="w-full border px-3 py-2" required />
             </div>
             <div class="mb-4">
-                <label class="block mb-1">Hasło</label>
+                <label class="block mb-1" portal-text="Account_Login_Password"></label>
                 <input type="password" name="password" class="w-full border px-3 py-2" required />
             </div>
-            <button type="submit" class="bg-black text-white px-4 py-2">Zaloguj</button>
+            <button type="submit" class="bg-black text-white px-4 py-2" portal-text="Account_Login_Button"></button>
         </form>
         @foreach (var err in ViewData.ModelState.Values.SelectMany(v => v.Errors))
         {

--- a/Portal/Views/Category/Accessories.cshtml
+++ b/Portal/Views/Category/Accessories.cshtml
@@ -1,6 +1,6 @@
 ﻿@model List<FashionStore.Models.ProductModel>
 @{
-    ViewData["Title"] = "AKCESORIA | CIUCHY";
+    ViewData["Title"] = $"{PortalTextService.Get("Category_Accessories_Title")} | CIUCHY";
 }
 
 <div class="category-page accessories-category-page">
@@ -14,17 +14,17 @@
         <div class="absolute top-1/2 left-1/4 transform -translate-y-1/2 -translate-x-1/4 z-10">
             <div class="max-w-xl">
                 <h1 class="text-6xl md:text-8xl font-light text-white tracking-tighter mb-4 hero-title">
-                    <span class="block">AKCESORIA</span>
+                    <span class="block" portal-text="Category_Accessories_Title"></span>
                 </h1>
                 <div class="w-16 h-1 bg-white mb-6"></div>
                 <p class="text-xl text-white/80 mb-8 hero-subtitle max-w-md">
-                    Odkryj naszą kolekcję akcesoriów, które dopełnią każdą stylizację i dodadzą jej charakteru
+                    <span portal-text="Category_Accessories_Subtitle"></span>
                 </p>
             </div>
         </div>
 
         <div class="absolute bottom-8 right-8 z-10 flex items-center text-white text-sm">
-            <span class="mr-2">PRZEWIŃ W DÓŁ</span>
+            <span class="mr-2" portal-text="Category_Accessories_Scroll"></span>
             <div class="animate-bounce">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 14l-7 7m0 0l-7-7m7 7V3" />

--- a/Portal/Views/Category/Kids.cshtml
+++ b/Portal/Views/Category/Kids.cshtml
@@ -1,6 +1,6 @@
 ﻿@model List<FashionStore.Models.ProductModel>
 @{
-    ViewData["Title"] = "DZIECI | CIUCHY";
+    ViewData["Title"] = $"{PortalTextService.Get("Category_Kids_Title")} | CIUCHY";
 }
 
 <div class="category-page kids-category-page">
@@ -14,17 +14,17 @@
         <div class="absolute top-1/2 left-1/4 transform -translate-y-1/2 -translate-x-1/4 z-10">
             <div class="max-w-xl">
                 <h1 class="text-6xl md:text-8xl font-light text-white tracking-tighter mb-4 hero-title">
-                    <span class="block">DZIECI</span>
+                    <span class="block" portal-text="Category_Kids_Title"></span>
                 </h1>
                 <div class="w-16 h-1 bg-white mb-6"></div>
                 <p class="text-xl text-white/80 mb-8 hero-subtitle max-w-md">
-                    Odkryj naszą kolekcję dla dzieci, która łączy wygodę, jakość i radosny design
+                    <span portal-text="Category_Kids_Subtitle"></span>
                 </p>
             </div>
         </div>
 
         <div class="absolute bottom-8 right-8 z-10 flex items-center text-white text-sm">
-            <span class="mr-2">PRZEWIŃ W DÓŁ</span>
+            <span class="mr-2" portal-text="Category_Kids_Scroll"></span>
             <div class="animate-bounce">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 14l-7 7m0 0l-7-7m7 7V3" />

--- a/Portal/Views/Category/Men.cshtml
+++ b/Portal/Views/Category/Men.cshtml
@@ -1,6 +1,6 @@
 ﻿@model List<FashionStore.Models.ProductModel>
 @{
-    ViewData["Title"] = "MĘŻCZYŹNI | CIUCHY";
+    ViewData["Title"] = $"{PortalTextService.Get("Category_Men_Title")} | CIUCHY";
 }
 
 <div class="category-page men-category-page">
@@ -14,17 +14,17 @@
         <div class="absolute top-1/2 left-1/4 transform -translate-y-1/2 -translate-x-1/4 z-10">
             <div class="max-w-xl">
                 <h1 class="text-6xl md:text-8xl font-light text-white tracking-tighter mb-4 hero-title">
-                    <span class="block">MĘŻCZYŹNI</span>
+                    <span class="block" portal-text="Category_Men_Title"></span>
                 </h1>
                 <div class="w-16 h-1 bg-white mb-6"></div>
                 <p class="text-xl text-white/80 mb-8 hero-subtitle max-w-md">
-                    Odkryj naszą kolekcję dla mężczyzn, która łączy nowoczesny design z ponadczasową elegancją
+                    <span portal-text="Category_Men_Subtitle"></span>
                 </p>
             </div>
         </div>
 
         <div class="absolute bottom-8 right-8 z-10 flex items-center text-white text-sm">
-            <span class="mr-2">PRZEWIŃ W DÓŁ</span>
+            <span class="mr-2" portal-text="Category_Men_Scroll"></span>
             <div class="animate-bounce">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 14l-7 7m0 0l-7-7m7 7V3" />

--- a/Portal/Views/Category/Women.cshtml
+++ b/Portal/Views/Category/Women.cshtml
@@ -1,6 +1,6 @@
 ﻿@model List<FashionStore.Models.ProductModel>
 @{
-    ViewData["Title"] = "KOBIETY | CIUCHY";
+    ViewData["Title"] = $"{PortalTextService.Get("Category_Women_Title")} | CIUCHY";
 }
 
 <div class="women-category-page">
@@ -14,17 +14,17 @@
         <div class="absolute top-1/2 left-1/4 transform -translate-y-1/2 -translate-x-1/4 z-10">
             <div class="max-w-xl">
                 <h1 class="text-6xl md:text-8xl font-light text-white tracking-tighter mb-4 hero-title">
-                    <span class="block">KOBIETY</span>
+                    <span class="block" portal-text="Category_Women_Title"></span>
                 </h1>
                 <div class="w-16 h-1 bg-white mb-6"></div>
                 <p class="text-xl text-white/80 mb-8 hero-subtitle max-w-md">
-                    Odkryj naszą kolekcję dla kobiet, która łączy nowoczesny design z ponadczasową elegancją
+                    <span portal-text="Category_Women_Subtitle"></span>
                 </p>
             </div>
         </div>
 
         <div class="absolute bottom-8 right-8 z-10 flex items-center text-white text-sm">
-            <span class="mr-2">PRZEWIŃ W DÓŁ</span>
+            <span class="mr-2" portal-text="Category_Women_Scroll"></span>
             <div class="animate-bounce">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 14l-7 7m0 0l-7-7m7 7V3" />

--- a/Portal/Views/Info/About.cshtml
+++ b/Portal/Views/Info/About.cshtml
@@ -1,5 +1,5 @@
 @{
-    ViewData["Title"] = "O firmie";
+    ViewData["Title"] = PortalTextService.Get("Info_About_HeroTitle");
 }
 <div class="relative h-64 overflow-hidden">
     <div class="absolute inset-0 z-0">
@@ -7,7 +7,7 @@
         <div class="hero-image absolute inset-0 bg-cover bg-center" style="background-image: url('/images/place-holder.jpg');"></div>
     </div>
     <div class="absolute top-1/2 left-1/2 transform -translate-y-1/2 -translate-x-1/2 z-10">
-        <h1 class="text-5xl md:text-6xl font-light text-white tracking-tight hero-title text-center">O FIRMIE</h1>
+        <h1 class="text-5xl md:text-6xl font-light text-white tracking-tight hero-title text-center" portal-text="Info_About_HeroTitle"></h1>
     </div>
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">

--- a/Portal/Views/Info/Contact.cshtml
+++ b/Portal/Views/Info/Contact.cshtml
@@ -1,5 +1,5 @@
 @{
-    ViewData["Title"] = "Kontakt";
+    ViewData["Title"] = PortalTextService.Get("Info_Contact_HeroTitle");
 }
 <div class="relative h-64 overflow-hidden">
     <div class="absolute inset-0 z-0">
@@ -7,7 +7,7 @@
         <div class="hero-image absolute inset-0 bg-cover bg-center" style="background-image: url('/images/place-holder.jpg');"></div>
     </div>
     <div class="absolute top-1/2 left-1/2 transform -translate-y-1/2 -translate-x-1/2 z-10">
-        <h1 class="text-5xl md:text-6xl font-light text-white tracking-tight hero-title text-center">KONTAKT</h1>
+        <h1 class="text-5xl md:text-6xl font-light text-white tracking-tight hero-title text-center" portal-text="Info_Contact_HeroTitle"></h1>
     </div>
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">

--- a/Portal/Views/Info/Faq.cshtml
+++ b/Portal/Views/Info/Faq.cshtml
@@ -1,5 +1,5 @@
 @{
-    ViewData["Title"] = "FAQ";
+    ViewData["Title"] = PortalTextService.Get("Info_Faq_HeroTitle");
 }
 <div class="relative h-64 overflow-hidden">
     <div class="absolute inset-0 z-0">
@@ -7,7 +7,7 @@
         <div class="hero-image absolute inset-0 bg-cover bg-center" style="background-image: url('/images/place-holder.jpg');"></div>
     </div>
     <div class="absolute top-1/2 left-1/2 transform -translate-y-1/2 -translate-x-1/2 z-10">
-        <h1 class="text-5xl md:text-6xl font-light text-white tracking-tight hero-title text-center">FAQ</h1>
+        <h1 class="text-5xl md:text-6xl font-light text-white tracking-tight hero-title text-center" portal-text="Info_Faq_HeroTitle"></h1>
     </div>
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">

--- a/Portal/Views/Info/Jobs.cshtml
+++ b/Portal/Views/Info/Jobs.cshtml
@@ -1,5 +1,5 @@
 @{
-    ViewData["Title"] = "Praca";
+    ViewData["Title"] = PortalTextService.Get("Info_Jobs_HeroTitle");
 }
 <div class="relative h-64 overflow-hidden">
     <div class="absolute inset-0 z-0">
@@ -7,7 +7,7 @@
         <div class="hero-image absolute inset-0 bg-cover bg-center" style="background-image: url('/images/place-holder.jpg');"></div>
     </div>
     <div class="absolute top-1/2 left-1/2 transform -translate-y-1/2 -translate-x-1/2 z-10">
-        <h1 class="text-5xl md:text-6xl font-light text-white tracking-tight hero-title text-center">PRACA</h1>
+        <h1 class="text-5xl md:text-6xl font-light text-white tracking-tight hero-title text-center" portal-text="Info_Jobs_HeroTitle"></h1>
     </div>
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">

--- a/Portal/Views/Info/Privacy.cshtml
+++ b/Portal/Views/Info/Privacy.cshtml
@@ -1,5 +1,5 @@
 @{
-    ViewData["Title"] = "Polityka prywatności";
+    ViewData["Title"] = PortalTextService.Get("Info_Privacy_HeroTitle");
 }
 <div class="relative h-64 overflow-hidden">
     <div class="absolute inset-0 z-0">
@@ -7,7 +7,7 @@
         <div class="hero-image absolute inset-0 bg-cover bg-center" style="background-image: url('/images/place-holder.jpg');"></div>
     </div>
     <div class="absolute top-1/2 left-1/2 transform -translate-y-1/2 -translate-x-1/2 z-10">
-        <h1 class="text-5xl md:text-6xl font-light text-white tracking-tight hero-title text-center">POLITYKA PRYWATNOŚCI</h1>
+        <h1 class="text-5xl md:text-6xl font-light text-white tracking-tight hero-title text-center" portal-text="Info_Privacy_HeroTitle"></h1>
     </div>
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">

--- a/Portal/Views/Info/Returns.cshtml
+++ b/Portal/Views/Info/Returns.cshtml
@@ -1,5 +1,5 @@
 @{
-    ViewData["Title"] = "Zwroty i reklamacje";
+    ViewData["Title"] = PortalTextService.Get("Info_Returns_HeroTitle");
 }
 <div class="relative h-64 overflow-hidden">
     <div class="absolute inset-0 z-0">
@@ -7,7 +7,7 @@
         <div class="hero-image absolute inset-0 bg-cover bg-center" style="background-image: url('/images/place-holder.jpg');"></div>
     </div>
     <div class="absolute top-1/2 left-1/2 transform -translate-y-1/2 -translate-x-1/2 z-10">
-        <h1 class="text-5xl md:text-6xl font-light text-white tracking-tight hero-title text-center">ZWROTY I REKLAMACJE</h1>
+        <h1 class="text-5xl md:text-6xl font-light text-white tracking-tight hero-title text-center" portal-text="Info_Returns_HeroTitle"></h1>
     </div>
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">

--- a/Portal/Views/Info/Shipping.cshtml
+++ b/Portal/Views/Info/Shipping.cshtml
@@ -1,5 +1,5 @@
 @{
-    ViewData["Title"] = "Dostawa i płatności";
+    ViewData["Title"] = PortalTextService.Get("Info_Shipping_HeroTitle");
 }
 <div class="relative h-64 overflow-hidden">
     <div class="absolute inset-0 z-0">
@@ -7,7 +7,7 @@
         <div class="hero-image absolute inset-0 bg-cover bg-center" style="background-image: url('/images/place-holder.jpg');"></div>
     </div>
     <div class="absolute top-1/2 left-1/2 transform -translate-y-1/2 -translate-x-1/2 z-10">
-        <h1 class="text-5xl md:text-6xl font-light text-white tracking-tight hero-title text-center">DOSTAWA I PŁATNOŚCI</h1>
+        <h1 class="text-5xl md:text-6xl font-light text-white tracking-tight hero-title text-center" portal-text="Info_Shipping_HeroTitle"></h1>
     </div>
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">

--- a/Portal/Views/Info/Terms.cshtml
+++ b/Portal/Views/Info/Terms.cshtml
@@ -1,5 +1,5 @@
 @{
-    ViewData["Title"] = "Regulamin";
+    ViewData["Title"] = PortalTextService.Get("Info_Terms_HeroTitle");
 }
 <div class="relative h-64 overflow-hidden">
     <div class="absolute inset-0 z-0">
@@ -7,7 +7,7 @@
         <div class="hero-image absolute inset-0 bg-cover bg-center" style="background-image: url('/images/place-holder.jpg');"></div>
     </div>
     <div class="absolute top-1/2 left-1/2 transform -translate-y-1/2 -translate-x-1/2 z-10">
-        <h1 class="text-5xl md:text-6xl font-light text-white tracking-tight hero-title text-center">REGULAMIN</h1>
+        <h1 class="text-5xl md:text-6xl font-light text-white tracking-tight hero-title text-center" portal-text="Info_Terms_HeroTitle"></h1>
     </div>
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">

--- a/Portal/_ViewImports.cshtml
+++ b/Portal/_ViewImports.cshtml
@@ -1,2 +1,3 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @inject Portal.Services.PortalTextService PortalTextService
+@addTagHelper *, Portal

--- a/sql/InsertPortalTexts.sql
+++ b/sql/InsertPortalTexts.sql
@@ -1,0 +1,71 @@
+/* Inserts initial portal texts used across the entire site */
+
+-- Category pages
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Category_Women_Title')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Category_Women_Title', 'KOBIETY', 'Category');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Category_Women_Subtitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Category_Women_Subtitle', 'Odkryj naszą kolekcję dla kobiet, która łączy nowoczesny design z ponadczasową elegancją', 'Category');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Category_Women_Scroll')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Category_Women_Scroll', 'PRZEWIŃ W DÓŁ', 'Category');
+
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Category_Men_Title')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Category_Men_Title', 'MĘŻCZYŹNI', 'Category');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Category_Men_Subtitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Category_Men_Subtitle', 'Odkryj naszą kolekcję dla mężczyzn, która łączy nowoczesny design z ponadczasową elegancją', 'Category');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Category_Men_Scroll')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Category_Men_Scroll', 'PRZEWIŃ W DÓŁ', 'Category');
+
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Category_Kids_Title')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Category_Kids_Title', 'DZIECI', 'Category');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Category_Kids_Subtitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Category_Kids_Subtitle', 'Odkryj naszą kolekcję dla dzieci, która łączy wygodę, jakość i radosny design', 'Category');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Category_Kids_Scroll')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Category_Kids_Scroll', 'PRZEWIŃ W DÓŁ', 'Category');
+
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Category_Accessories_Title')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Category_Accessories_Title', 'AKCESORIA', 'Category');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Category_Accessories_Subtitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Category_Accessories_Subtitle', 'Odkryj naszą kolekcję akcesoriów, które dopełnią każdą stylizację i dodadzą jej charakteru', 'Category');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Category_Accessories_Scroll')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Category_Accessories_Scroll', 'PRZEWIŃ W DÓŁ', 'Category');
+
+-- Info pages
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_About_HeroTitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Info_About_HeroTitle', 'O FIRMIE', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Jobs_HeroTitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Info_Jobs_HeroTitle', 'PRACA', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Privacy_HeroTitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Info_Privacy_HeroTitle', 'POLITYKA PRYWATNOŚCI', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Shipping_HeroTitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Info_Shipping_HeroTitle', 'DOSTAWA I PŁATNOŚCI', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Terms_HeroTitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Info_Terms_HeroTitle', 'REGULAMIN', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Returns_HeroTitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Info_Returns_HeroTitle', 'ZWROTY I REKLAMACJE', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Faq_HeroTitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Info_Faq_HeroTitle', 'FAQ', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Contact_HeroTitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Info_Contact_HeroTitle', 'KONTAKT', 'Info');
+
+-- Account/Login
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Account_Login_Title')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Account_Login_Title', 'Logowanie', 'Account');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Account_Login_Email')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Account_Login_Email', 'Email', 'Account');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Account_Login_Password')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Account_Login_Password', 'Hasło', 'Account');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Account_Login_Button')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Account_Login_Button', 'Zaloguj', 'Account');
+GO


### PR DESCRIPTION
## Summary
- add PortalTextTagHelper for easy text injection
- enable tag helper in views
- use dynamic texts on category, info, and login pages
- provide SQL script with sample texts

## Testing
- `dotnet build Intranet/Intranet.csproj`
- `dotnet build Portal/Portal.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68456f4eb6f083308ca02df81879c055