### PR TITLE
Add editable texts for info pages

### DIFF
--- a/Portal/TagHelpers/PortalTextTagHelper.cs
+++ b/Portal/TagHelpers/PortalTextTagHelper.cs
@@ -19,6 +19,6 @@ public class PortalTextTagHelper : TagHelper
     public override void Process(TagHelperContext context, TagHelperOutput output)
     {
         var value = _service.Get(Key);
-        output.Content.SetContent(value);
+        output.Content.SetHtmlContent(value);
     }
 }

--- a/Portal/Views/Info/About.cshtml
+++ b/Portal/Views/Info/About.cshtml
@@ -12,7 +12,7 @@
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">
     <div class="max-w-3xl mx-auto text-gray-700 space-y-4">
-        <p>CIUCHY to marka łącząca pasję do mody z wysoką jakością wykonania. Tworzymy ubrania, które pozwalają wyrazić indywidualny styl.</p>
-        <p>Nasz zespół dba o każdy detal, dzięki czemu oferujemy kolekcje dopracowane i zgodne z najnowszymi trendami.</p>
+        <p portal-text="Info_About_Text1"></p>
+        <p portal-text="Info_About_Text2"></p>
     </div>
 </section>

--- a/Portal/Views/Info/Contact.cshtml
+++ b/Portal/Views/Info/Contact.cshtml
@@ -12,7 +12,7 @@
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">
     <div class="max-w-3xl mx-auto text-gray-700 space-y-4">
-        <p>Masz pytania? Skontaktuj się z nami pod adresem <strong>kontakt@ciuchy.pl</strong> lub telefonicznie: <strong>+48 123 456 789</strong>.</p>
-        <p>Odpowiadamy na wiadomości w dni robocze w godzinach 9:00-17:00.</p>
+        <p portal-text="Info_Contact_Text1"></p>
+        <p portal-text="Info_Contact_Text2"></p>
     </div>
 </section>

--- a/Portal/Views/Info/Faq.cshtml
+++ b/Portal/Views/Info/Faq.cshtml
@@ -12,7 +12,7 @@
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">
     <div class="max-w-3xl mx-auto text-gray-700 space-y-4">
-        <p>Najczęściej zadawane pytania dotyczące zakupów w naszym sklepie znajdziesz poniżej.</p>
-        <p>Jeśli nie znalazłeś odpowiedzi, napisz do nas – chętnie pomożemy.</p>
+        <p portal-text="Info_Faq_Text1"></p>
+        <p portal-text="Info_Faq_Text2"></p>
     </div>
 </section>

--- a/Portal/Views/Info/Jobs.cshtml
+++ b/Portal/Views/Info/Jobs.cshtml
@@ -12,7 +12,7 @@
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">
     <div class="max-w-3xl mx-auto text-gray-700 space-y-4">
-        <p>Szukasz inspirującego miejsca pracy? W CIUCHY stawiamy na kreatywność i rozwój. Regularnie poszukujemy osób pełnych pasji do mody.</p>
-        <p>Wyślij swoje CV na adres <strong>praca@ciuchy.pl</strong> i dołącz do naszego zespołu.</p>
+        <p portal-text="Info_Jobs_Text1"></p>
+        <p portal-text="Info_Jobs_Text2"></p>
     </div>
 </section>

--- a/Portal/Views/Info/Privacy.cshtml
+++ b/Portal/Views/Info/Privacy.cshtml
@@ -12,7 +12,7 @@
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">
     <div class="max-w-3xl mx-auto text-gray-700 space-y-4">
-        <p>Chronimy Twoje dane osobowe i przetwarzamy je zgodnie z obowiązującymi przepisami. Szczegóły dotyczące przetwarzania danych znajdziesz poniżej.</p>
-        <p>W razie pytań dotyczących prywatności skontaktuj się z nami poprzez formularz kontaktowy.</p>
+        <p portal-text="Info_Privacy_Text1"></p>
+        <p portal-text="Info_Privacy_Text2"></p>
     </div>
 </section>

--- a/Portal/Views/Info/Returns.cshtml
+++ b/Portal/Views/Info/Returns.cshtml
@@ -12,7 +12,7 @@
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">
     <div class="max-w-3xl mx-auto text-gray-700 space-y-4">
-        <p>Masz 14 dni na zwrot towaru bez podania przyczyny. Reklamacje rozpatrujemy w ciągu 14 dni od ich otrzymania.</p>
-        <p>Aby rozpocząć proces zwrotu lub reklamacji, napisz na <strong>reklamacje@ciuchy.pl</strong>.</p>
+        <p portal-text="Info_Returns_Text1"></p>
+        <p portal-text="Info_Returns_Text2"></p>
     </div>
 </section>

--- a/Portal/Views/Info/Shipping.cshtml
+++ b/Portal/Views/Info/Shipping.cshtml
@@ -12,7 +12,7 @@
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">
     <div class="max-w-3xl mx-auto text-gray-700 space-y-4">
-        <p>Zamówienia realizujemy w ciągu 1-2 dni roboczych. Dostawy obsługuje firma kurierska oraz paczkomaty.</p>
-        <p>Akceptujemy płatności przelewem, kartą oraz za pobraniem. Szczegóły wyświetlane są na etapie finalizacji zamówienia.</p>
+        <p portal-text="Info_Shipping_Text1"></p>
+        <p portal-text="Info_Shipping_Text2"></p>
     </div>
 </section>

--- a/Portal/Views/Info/Terms.cshtml
+++ b/Portal/Views/Info/Terms.cshtml
@@ -12,7 +12,7 @@
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">
     <div class="max-w-3xl mx-auto text-gray-700 space-y-4">
-        <p>Niniejszy regulamin określa zasady korzystania ze sklepu CIUCHY. Dokonując zakupu, akceptujesz poniższe warunki.</p>
-        <p>Pełną wersję regulaminu znajdziesz w dokumentach dostępnych w naszym biurze obsługi klienta.</p>
+        <p portal-text="Info_Terms_Text1"></p>
+        <p portal-text="Info_Terms_Text2"></p>
     </div>
 </section>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# Portal Intranet
+
+Po zaktualizowaniu aplikacji uruchom skrypt `sql/UpdateHomeTextSections.sql`, aby ustawić sekcje `Home` i `Layout` dla istniejących wpisów w tabeli `PortalTexts`.
+Następnie wykonaj `sql/InsertPortalTexts.sql`, aby dodać brakujące teksty (m.in. akapity stron informacyjnych).

--- a/sql/InsertPortalTexts.sql
+++ b/sql/InsertPortalTexts.sql
@@ -1,5 +1,22 @@
 /* Inserts initial portal texts used across the entire site */
 
+-- Layout texts
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Header_Brand')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Header_Brand', 'CIUCHY', 'Layout');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Nav_Women')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Nav_Women', 'KOBIETY', 'Layout');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Nav_Men')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Nav_Men', 'MĘŻCZYŹNI', 'Layout');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Nav_Kids')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Nav_Kids', 'DZIECI', 'Layout');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Nav_Accessories')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Nav_Accessories', 'AKCESORIA', 'Layout');
+
 -- Category pages
 IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Category_Women_Title')
     INSERT INTO PortalTexts([Key], [Value], [Section])
@@ -59,6 +76,55 @@ IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Faq_HeroTitle')
 IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Contact_HeroTitle')
     INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Info_Contact_HeroTitle', 'KONTAKT', 'Info');
 
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_About_Text1')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_About_Text1', 'CIUCHY to marka łącząca pasję do mody z wysoką jakością wykonania. Tworzymy ubrania, które pozwalają wyrazić indywidualny styl.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_About_Text2')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_About_Text2', 'Nasz zespół dba o każdy detal, dzięki czemu oferujemy kolekcje dopracowane i zgodne z najnowszymi trendami.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Jobs_Text1')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Jobs_Text1', 'Szukasz inspirującego miejsca pracy? W CIUCHY stawiamy na kreatywność i rozwój. Regularnie poszukujemy osób pełnych pasji do mody.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Jobs_Text2')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Jobs_Text2', 'Wyślij swoje CV na adres <strong>praca@ciuchy.pl</strong> i dołącz do naszego zespołu.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Privacy_Text1')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Privacy_Text1', 'Chronimy Twoje dane osobowe i przetwarzamy je zgodnie z obowiązującymi przepisami. Szczegóły dotyczące przetwarzania danych znajdziesz poniżej.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Privacy_Text2')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Privacy_Text2', 'W razie pytań dotyczących prywatności skontaktuj się z nami poprzez formularz kontaktowy.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Shipping_Text1')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Shipping_Text1', 'Zamówienia realizujemy w ciągu 1-2 dni roboczych. Dostawy obsługuje firma kurierska oraz paczkomaty.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Shipping_Text2')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Shipping_Text2', 'Akceptujemy płatności przelewem, kartą oraz za pobraniem. Szczegóły wyświetlane są na etapie finalizacji zamówienia.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Terms_Text1')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Terms_Text1', 'Niniejszy regulamin określa zasady korzystania ze sklepu CIUCHY. Dokonując zakupu, akceptujesz poniższe warunki.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Terms_Text2')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Terms_Text2', 'Pełną wersję regulaminu znajdziesz w dokumentach dostępnych w naszym biurze obsługi klienta.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Returns_Text1')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Returns_Text1', 'Masz 14 dni na zwrot towaru bez podania przyczyny. Reklamacje rozpatrujemy w ciągu 14 dni od ich otrzymania.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Returns_Text2')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Returns_Text2', 'Aby rozpocząć proces zwrotu lub reklamacji, napisz na <strong>reklamacje@ciuchy.pl</strong>.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Faq_Text1')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Faq_Text1', 'Najczęściej zadawane pytania dotyczące zakupów w naszym sklepie znajdziesz poniżej.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Faq_Text2')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Faq_Text2', 'Jeśli nie znalazłeś odpowiedzi, napisz do nas – chętnie pomożemy.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Contact_Text1')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Contact_Text1', 'Masz pytania? Skontaktuj się z nami pod adresem <strong>kontakt@ciuchy.pl</strong> lub telefonicznie: <strong>+48 123 456 789</strong>.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Contact_Text2')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Contact_Text2', 'Odpowiadamy na wiadomości w dni robocze w godzinach 9:00-17:00.', 'Info');
+
 -- Account/Login
 IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Account_Login_Title')
     INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Account_Login_Title', 'Logowanie', 'Account');
@@ -68,4 +134,42 @@ IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Account_Login_Password')
     INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Account_Login_Password', 'Hasło', 'Account');
 IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Account_Login_Button')
     INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Account_Login_Button', 'Zaloguj', 'Account');
+
+-- Home page
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_HeroTop')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_HeroTop', 'NOWA KOLEKCJA', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_HeroBottom')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_HeroBottom', 'WIOSNA/LATO', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_HeroSubtitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_HeroSubtitle', 'Najmodniejsze trendy tego sezonu', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_HeroButton')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_HeroButton', 'ODKRYJ KOLEKCJĘ', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_CategoriesTitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_CategoriesTitle', 'KATEGORIE', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_CategoriesSubtitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_CategoriesSubtitle', 'Odkryj nasze sekcje i znajdź coś dla siebie', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_FeaturedTitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_FeaturedTitle', 'WYRÓŻNIONE PRODUKTY', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_FeaturedSubtitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_FeaturedSubtitle', 'Sprawdź nasze bestsellery', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_ShowMore')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_ShowMore', 'POKAŻ WIĘCEJ', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_LookbookTitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_LookbookTitle', 'LOOKBOOK', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_LookbookSubtitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_LookbookSubtitle', 'Zainspiruj się naszymi stylizacjami', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_LookbookButton')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_LookbookButton', 'POKAŻ LOOKBOOK', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_NewsletterTitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_NewsletterTitle', 'NEWSLETTER', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_NewsletterSubtitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_NewsletterSubtitle', 'Zapisz się, aby otrzymywać najnowsze informacje i oferty', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_NewsletterPlaceholder')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_NewsletterPlaceholder', 'Wpisz swój email', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_NewsletterButton')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_NewsletterButton', 'ZAPISZ SIĘ', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_InstagramTitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_InstagramTitle', 'INSTAGRAM', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_InstagramSubtitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_InstagramSubtitle', 'Obserwuj nas na Instagramie', 'Home');
 GO

--- a/sql/UpdateHomeTextSections.sql
+++ b/sql/UpdateHomeTextSections.sql
@@ -1,0 +1,17 @@
+-- Assigns Home section to existing portal texts whose keys begin with Home_
+-- and have no section set
+UPDATE PortalTexts
+SET Section = 'Home'
+WHERE [Key] LIKE 'Home_%' AND (Section IS NULL OR Section = '');
+
+-- Assign Layout section to navigation and header texts that lack it
+UPDATE PortalTexts
+SET Section = 'Layout'
+WHERE [Key] IN ('Header_Brand', 'Nav_Women', 'Nav_Men', 'Nav_Kids', 'Nav_Accessories')
+  AND (Section IS NULL OR Section = '');
+
+-- Assign Info section to texts related to info pages
+UPDATE PortalTexts
+SET Section = 'Info'
+WHERE [Key] LIKE 'Info_%' AND (Section IS NULL OR Section = '');
+GO


### PR DESCRIPTION
## Summary
- make PortalTextTagHelper allow HTML content
- seed paragraph texts for info pages
- map all info page paragraphs to portal texts
- ensure UpdateHomeTextSections handles info pages
- mention running InsertPortalTexts.sql

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68457ccb4e8883309fbed9d1cdc0a08e