### PR TITLE
Add editable texts for info pages

### DIFF
--- a/Intranet/Controllers/AdminController.cs
+++ b/Intranet/Controllers/AdminController.cs
@@ -2,7 +2,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using System.Threading.Tasks; // Dodaj ten using, jeśli go brakuje
+using System.Threading.Tasks;
 
 namespace Intranet.Controllers
 {
@@ -10,46 +10,33 @@ namespace Intranet.Controllers
     public class AdminController : Controller
     {
         private readonly IntranetContext _db;
-        // W konstruktorze typ parametru 'db' jest poprawny (IntranetContext)
         public AdminController(IntranetContext db) => _db = db;
 
-        // GET: /Admin
         public async Task<IActionResult> Index()
         {
-            // ZMIANA: _db.Pracownicy -> _db.Pracownicies
-            // ZMIANA: Typ zmiennej 'users' będzie teraz List<Pracownicies>
             var users = await _db.Pracownicies.ToListAsync();
-            return View(users); // Widok Index.cshtml dla Admin musi oczekiwać @model IEnumerable<Intranet.Models.Pracownicies>
+            return View(users);
         }
 
-        // GET: /Admin/Create
-        public IActionResult Create() => View(); // Widok Create.cshtml dla Admin musi oczekiwać @model Intranet.Models.Pracownicies
+        public IActionResult Create() => View();
 
-        // POST: /Admin/Create
         [HttpPost, ValidateAntiForgeryToken]
-        // ZMIANA: Typ parametru Pracownicy -> Pracownicies
         public async Task<IActionResult> Create(Pracownicy user)
         {
             if (!ModelState.IsValid) return View(user);
-            // ZMIANA: _db.Pracownicy -> _db.Pracownicies
             _db.Pracownicies.Add(user);
             await _db.SaveChangesAsync();
             return RedirectToAction(nameof(Index));
         }
 
-        // GET: /Admin/Edit/5
         public async Task<IActionResult> Edit(int id)
         {
-            // ZMIANA: _db.Pracownicy -> _db.Pracownicies
-            // ZMIANA: Typ zmiennej 'user' będzie teraz Pracownicies?
             var user = await _db.Pracownicies.FindAsync(id);
             if (user == null) return NotFound();
-            return View(user); // Widok Edit.cshtml dla Admin musi oczekiwać @model Intranet.Models.Pracownicies
+            return View(user);
         }
 
-        // POST: /Admin/Edit/5
         [HttpPost, ValidateAntiForgeryToken]
-        // ZMIANA: Typ parametru Pracownicy -> Pracownicies
         public async Task<IActionResult> Edit(int id, Pracownicy user)
         {
             if (id != user.Id) return BadRequest();
@@ -60,25 +47,19 @@ namespace Intranet.Controllers
             return RedirectToAction(nameof(Index));
         }
 
-        // GET: /Admin/Delete/5
         public async Task<IActionResult> Delete(int id)
         {
-            // ZMIANA: _db.Pracownicy -> _db.Pracownicies
-            // ZMIANA: Typ zmiennej 'user' będzie teraz Pracownicies?
             var user = await _db.Pracownicies.FindAsync(id);
             if (user == null) return NotFound();
-            return View(user); // Widok Delete.cshtml dla Admin musi oczekiwać @model Intranet.Models.Pracownicies
+            return View(user);
         }
 
-        // POST: /Admin/Delete/5
         [HttpPost, ActionName("Delete"), ValidateAntiForgeryToken]
         public async Task<IActionResult> DeleteConfirmed(int id)
         {
-            // ZMIANA: _db.Pracownicy -> _db.Pracownicies
             var user = await _db.Pracownicies.FindAsync(id);
             if (user != null)
             {
-                // ZMIANA: _db.Pracownicy -> _db.Pracownicies
                 _db.Pracownicies.Remove(user);
                 await _db.SaveChangesAsync();
             }

--- a/Intranet/Controllers/AuthController.cs
+++ b/Intranet/Controllers/AuthController.cs
@@ -1,4 +1,4 @@
-﻿// Controllers/AuthController.cs
+﻿
 using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
@@ -30,7 +30,6 @@ namespace Intranet.Controllers
             if (!ModelState.IsValid)
                 return View(vm);
 
-            // dopasuj nazwę właściwości do swojego modelu, np. HasloHash
             var user = await _db.Pracownicies
                 .SingleOrDefaultAsync(u =>
                     u.Email == vm.Email &&
@@ -43,7 +42,6 @@ namespace Intranet.Controllers
                 return View(vm);
             }
 
-            // budujemy claims z dodatkowymi informacjami
             var claims = new List<Claim>
             {
                 new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
@@ -55,7 +53,6 @@ namespace Intranet.Controllers
             var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
             var principal = new ClaimsPrincipal(identity);
 
-            // logujemy i ustawiamy ciasteczko
             await HttpContext.SignInAsync(
                 CookieAuthenticationDefaults.AuthenticationScheme,
                 principal,
@@ -66,7 +63,6 @@ namespace Intranet.Controllers
                 }
             );
 
-            // przekierowanie na stronę, z której przyszedł
             if (Url.IsLocalUrl(returnUrl))
                 return Redirect(returnUrl!);
 

--- a/Intranet/Controllers/HarmonogramController.cs
+++ b/Intranet/Controllers/HarmonogramController.cs
@@ -27,10 +27,6 @@ namespace Intranet.Controllers
             var userIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
             if (string.IsNullOrEmpty(userIdString) || !int.TryParse(userIdString, out var userId))
             {
-                // Rozważ odpowiednią obsługę błędu, np. return Unauthorized();
-                // lub przekierowanie do strony błędu/logowania.
-                // Na razie, dla uproszczenia, można rzucić wyjątek lub zwrócić błąd.
-                // W praktyce produkcyjnej lepiej obsłużyć to bardziej elegancko.
                 return BadRequest("Nie można zidentyfikować użytkownika.");
             }
 

--- a/Intranet/Controllers/OgloszeniaController.cs
+++ b/Intranet/Controllers/OgloszeniaController.cs
@@ -1,12 +1,12 @@
 ﻿using Intranet.Models;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore; // Może być potrzebne, jeśli będziesz robić bardziej złożone operacje
+using Microsoft.EntityFrameworkCore;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authorization; // Jeśli chcesz ograniczyć dostęp
+using Microsoft.AspNetCore.Authorization;
 
 namespace Intranet.Controllers
 {
-    [Authorize(Roles = "Admin")] // Tylko Admin może zarządzać ogłoszeniami (przykład)
+    [Authorize(Roles = "Admin")]
     public class OgloszeniaController : Controller
     {
         private readonly IntranetContext _context;
@@ -16,38 +16,30 @@ namespace Intranet.Controllers
             _context = context;
         }
 
-        // GET: Ogloszenia/Create
         public IActionResult Create()
         {
-            // Możemy przekazać domyślne wartości, np. bieżącą datę
             var model = new Ogloszenie
             {
-                DataPublikacji = DateTime.Today // Domyślnie dzisiejsza data
+                DataPublikacji = DateTime.Today
             };
             return View(model);
         }
 
-        // POST: Ogloszenia/Create
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create(
             [Bind("Tytul,Tresc,DataPublikacji,Dzial,Typ,CzyWazne")] Ogloszenie ogloszenie)
         {
-            // Możesz chcieć ustawić DataPublikacji na serwerze, jeśli nie ufasz dacie od klienta
-            // ogloszenie.DataPublikacji = DateTime.UtcNow;
 
             if (ModelState.IsValid)
             {
                 _context.Add(ogloszenie);
                 await _context.SaveChangesAsync();
                 TempData["SuccessMessage"] = "Ogłoszenie zostało pomyślnie dodane.";
-                // Przekieruj np. do listy ogłoszeń (jeśli ją stworzysz) lub z powrotem do dashboardu
-                return RedirectToAction("Index", "Home"); // Na razie wracamy do dashboardu
+                return RedirectToAction("Index", "Home");
             }
-            // Jeśli model nie jest poprawny, wróć do formularza z błędami
             return View(ogloszenie);
         }
 
-        // Możesz tu później dodać akcje Index (do listowania wszystkich ogłoszeń), Edit, Delete itp.
     }
 }

--- a/Intranet/Controllers/PortalTextsController.cs
+++ b/Intranet/Controllers/PortalTextsController.cs
@@ -15,7 +15,6 @@ public class PortalTextsController : Controller
         _context = context;
     }
 
-    // GET: PortalTexts/Sections
     public async Task<IActionResult> Sections()
     {
         var sections = await _context.PortalTexts
@@ -26,7 +25,6 @@ public class PortalTextsController : Controller
         return View(sections);
     }
 
-    // GET: PortalTexts
     public async Task<IActionResult> Index(string? section)
     {
         var sections = await _context.PortalTexts
@@ -46,13 +44,11 @@ public class PortalTextsController : Controller
         return View(texts);
     }
 
-    // GET: PortalTexts/Create
     public IActionResult Create()
     {
         return View(new PortalText());
     }
 
-    // POST: PortalTexts/Create
     [HttpPost]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Create([Bind("Key,Value,Section")] PortalText text)
@@ -66,7 +62,6 @@ public class PortalTextsController : Controller
         return View(text);
     }
 
-    // GET: PortalTexts/Edit/5
     public async Task<IActionResult> Edit(int id)
     {
         var text = await _context.PortalTexts.FindAsync(id);
@@ -74,7 +69,6 @@ public class PortalTextsController : Controller
         return View(text);
     }
 
-    // POST: PortalTexts/Edit/5
     [HttpPost]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Edit(int id, [Bind("Id,Key,Value,Section")] PortalText text)
@@ -90,7 +84,6 @@ public class PortalTextsController : Controller
         return View(text);
     }
 
-    // GET: PortalTexts/Delete/5
     public async Task<IActionResult> Delete(int id)
     {
         var text = await _context.PortalTexts.FindAsync(id);
@@ -98,7 +91,6 @@ public class PortalTextsController : Controller
         return View(text);
     }
 
-    // POST: PortalTexts/Delete/5
     [HttpPost, ActionName("Delete")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> DeleteConfirmed(int id)

--- a/Intranet/Controllers/UrlopController.cs
+++ b/Intranet/Controllers/UrlopController.cs
@@ -1,123 +1,103 @@
-﻿using Intranet.Models; // Upewnij się, że ten using jest dla IntranetContext, Urlopy, UrlopStatus
+﻿using Intranet.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
-using Microsoft.EntityFrameworkCore; // Dla .Include(), .ToListAsync(), .FindAsync()
-using System.Linq;                 // Dla .AsQueryable(), .Where(), .OrderBy()
-using System.Threading.Tasks;    // Dla async/await
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Intranet.Controllers
 {
-    [Authorize] // Wszystkie akcje w tym kontrolerze wymagają autoryzacji
+    [Authorize]
     public class UrlopController : Controller
     {
-        private readonly IntranetContext _db; // Wstrzyknięty DbContext
+        private readonly IntranetContext _db;
 
-        // Usunięto: public object UrlopStatus { get; private set; }
 
         public UrlopController(IntranetContext db)
         {
             _db = db;
         }
 
-        // GET: /Urlop lub /Urlop/Index
         public async Task<IActionResult> Index()
         {
             var userIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
-            // Bezpieczne parsowanie ID użytkownika
             if (string.IsNullOrEmpty(userIdString) || !int.TryParse(userIdString, out var userId))
             {
-                // Jeśli ID użytkownika nie jest dostępne lub nie jest poprawną liczbą,
-                // można zwrócić błąd lub przekierować do strony logowania.
-                // Unauthorized() może być odpowiednie, jeśli użytkownik powinien być zalogowany.
                 return Unauthorized("Nie można zidentyfikować użytkownika.");
             }
 
-            var isAdmin = User.IsInRole("Admin"); // Sprawdzenie, czy użytkownik ma rolę Admin
+            var isAdmin = User.IsInRole("Admin");
 
-            // Pobieranie urlopów z bazy danych
-            // Używamy _db.Urlopies (zgodnie z nazwą DbSet w IntranetContext)
             IQueryable<Urlopy> query = _db.Urlopies
-                                          .Include(u => u.Pracownik); // Dołączamy dane pracownika
+                                          .Include(u => u.Pracownik);
 
             if (!isAdmin)
             {
-                // Zwykły użytkownik widzi tylko swoje urlopy
                 query = query.Where(u => u.PracownikId == userId);
             }
 
-            // Sortowanie i pobranie listy
             var urlopyList = await query.OrderBy(u => u.DataOd).ToListAsync();
 
-            return View(urlopyList); // Przekazanie listy urlopów do widoku
+            return View(urlopyList);
         }
 
-        // GET: /Urlop/Create
         public IActionResult Create()
         {
-            // Zwraca widok do tworzenia nowego urlopu.
-            // Można tu przekazać pusty model lub dane do list rozwijanych, jeśli są potrzebne.
-            return View(new Urlopy()); // Przekazanie nowego obiektu Urlopy, aby formularz był silnie typowany
+            return View(new Urlopy());
         }
 
-        // POST: /Urlop/Create
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Create(Urlopy urlopViewModel) // Model z danymi z formularza
+        public async Task<IActionResult> Create(Urlopy urlopViewModel)
         {
-            // Sprawdzenie, czy model przeszedł walidację (np. atrybuty [Required])
             if (ModelState.IsValid)
             {
                 var userIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
                 if (string.IsNullOrEmpty(userIdString) || !int.TryParse(userIdString, out var userId))
                 {
                     ModelState.AddModelError(string.Empty, "Nie można zidentyfikować użytkownika.");
-                    return View(urlopViewModel); // Wróć do formularza z błędem
+                    return View(urlopViewModel);
                 }
 
-                // Ustawienie pól, które nie pochodzą bezpośrednio z formularza
                 urlopViewModel.PracownikId = userId;
-                urlopViewModel.Status = Models.UrlopStatus.Oczekuje; // Użycie enuma
+                urlopViewModel.Status = Models.UrlopStatus.Oczekuje;
 
-                _db.Urlopies.Add(urlopViewModel); // Dodanie nowego urlopu do DbContext
-                await _db.SaveChangesAsync();   // Zapisanie zmian w bazie danych
+                _db.Urlopies.Add(urlopViewModel);
+                await _db.SaveChangesAsync();
 
-                return RedirectToAction(nameof(Index)); // Przekierowanie do listy urlopów
+                return RedirectToAction(nameof(Index));
             }
-            return View(urlopViewModel); // Jeśli model nie jest poprawny, wróć do formularza z błędami walidacji
+            return View(urlopViewModel);
         }
 
-        // POST: /Urlop/Approve/5
-        [Authorize(Roles = "Admin")] // Tylko Admin może zatwierdzać
+        [Authorize(Roles = "Admin")]
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Approve(int id) // ID urlopu do zatwierdzenia
+        public async Task<IActionResult> Approve(int id)
         {
-            var urlop = await _db.Urlopies.FindAsync(id); // Znajdź urlop w bazie
+            var urlop = await _db.Urlopies.FindAsync(id);
 
-            if (urlop != null && urlop.Status == Models.UrlopStatus.Oczekuje) // Sprawdź, czy istnieje i czy status to Oczekuje
+            if (urlop != null && urlop.Status == Models.UrlopStatus.Oczekuje)
             {
-                urlop.Status = Models.UrlopStatus.Zaakceptowany; // Zmień status na Zaakceptowany
-                await _db.SaveChangesAsync();                  // Zapisz zmiany
+                urlop.Status = Models.UrlopStatus.Zaakceptowany;
+                await _db.SaveChangesAsync();
             }
-            // Można dodać TempData lub ViewBag z komunikatem o sukcesie/błędzie
             return RedirectToAction(nameof(Index));
         }
 
-        // POST: /Urlop/Reject/5
-        [Authorize(Roles = "Admin")] // Tylko Admin może odrzucać
+        [Authorize(Roles = "Admin")]
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Reject(int id) // ID urlopu do odrzucenia
+        public async Task<IActionResult> Reject(int id)
         {
-            var urlop = await _db.Urlopies.FindAsync(id); // Znajdź urlop w bazie
+            var urlop = await _db.Urlopies.FindAsync(id);
 
-            if (urlop != null && urlop.Status == Models.UrlopStatus.Oczekuje) // Sprawdź, czy istnieje i czy status to Oczekuje
+            if (urlop != null && urlop.Status == Models.UrlopStatus.Oczekuje)
             {
-                urlop.Status = Models.UrlopStatus.Odrzucony; // Zmień status na Odrzucony
-                await _db.SaveChangesAsync();                // Zapisz zmiany
+                urlop.Status = Models.UrlopStatus.Odrzucony;
+                await _db.SaveChangesAsync();
             }
-            // Można dodać TempData lub ViewBag z komunikatem o sukcesie/błędzie
             return RedirectToAction(nameof(Index));
         }
     }

--- a/Intranet/Controllers/ZadaniaController.cs
+++ b/Intranet/Controllers/ZadaniaController.cs
@@ -1,4 +1,4 @@
-﻿// W Controllers/ZadaniaController.cs
+﻿
 using Intranet.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace Intranet.Controllers
 {
-    [Authorize] // Wszystkie akcje w tym kontrolerze wymagają autoryzacji
+    [Authorize]
     public class ZadaniaController : Controller
     {
         private readonly IntranetContext _context;
@@ -20,7 +20,6 @@ namespace Intranet.Controllers
             _context = context;
         }
 
-        // Akcja do przełączania statusu CzyWykonane zadania
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> ToggleWykonane(int id)
@@ -32,8 +31,6 @@ namespace Intranet.Controllers
                 return NotFound();
             }
 
-            // Sprawdzenie, czy zalogowany użytkownik jest właścicielem zadania
-            // lub czy jest adminem (opcjonalna dodatkowa weryfikacja)
             var userIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
             if (!int.TryParse(userIdString, out var currentUserId))
             {
@@ -45,53 +42,45 @@ namespace Intranet.Controllers
                 return Forbid("Nie masz uprawnień do modyfikacji tego zadania.");
             }
 
-            zadanie.CzyWykonane = !zadanie.CzyWykonane; // Przełącz status
+            zadanie.CzyWykonane = !zadanie.CzyWykonane;
             if (zadanie.CzyWykonane)
             {
-                zadanie.DataWykonania = DateTime.UtcNow; // Ustaw datę wykonania
+                zadanie.DataWykonania = DateTime.UtcNow;
             }
             else
             {
-                zadanie.DataWykonania = null; // Usuń datę wykonania, jeśli oznaczono jako niewykonane
+                zadanie.DataWykonania = null;
             }
 
             _context.Update(zadanie);
             await _context.SaveChangesAsync();
 
-            // Przekieruj z powrotem do strony, z której przyszło żądanie (np. dashboard)
-            // Można też użyć Request.Headers["Referer"].ToString() jeśli jest dostępne i bezpieczne
             return RedirectToAction("Index", "Home");
         }
 
 
-        // GET: Zadania/Create (dla dodawania nowego zadania - zrobimy to później)
         public IActionResult Create()
         {
-            // Pobierz ID zalogowanego użytkownika, aby przypisać zadanie
             var userIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
             if (string.IsNullOrEmpty(userIdString) || !int.TryParse(userIdString, out var userId))
             {
-                // Obsłuż błąd - użytkownik musi być zalogowany, aby dodać zadanie dla siebie
                 TempData["ErrorMessage"] = "Nie można zidentyfikować użytkownika. Zaloguj się ponownie.";
                 return RedirectToAction("Index", "Home");
             }
 
             var model = new Zadanie
             {
-                PracownikId = userId, // Domyślnie przypisz do zalogowanego użytkownika
+                PracownikId = userId,
                 DataUtworzenia = DateTime.UtcNow,
-                TerminWykonania = DateTime.Today.AddDays(7) // Domyślny termin np. za tydzień
+                TerminWykonania = DateTime.Today.AddDays(7)
             };
             return View(model);
         }
 
-        // POST: Zadania/Create
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create([Bind("Tytul,Opis,TerminWykonania,Priorytet,PracownikId")] Zadanie zadanie)
         {
-            // Upewnij się, że PracownikId jest ustawione (np. z ukrytego pola lub pobrane z claimów)
-            // Jeśli PracownikId nie jest w [Bind], ustaw je tutaj:
             if (zadanie.PracownikId == 0)
             {
                 var userIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
@@ -114,14 +103,12 @@ namespace Intranet.Controllers
                 _context.Add(zadanie);
                 await _context.SaveChangesAsync();
                 TempData["SuccessMessage"] = "Nowe zadanie zostało pomyślnie dodane.";
-                return RedirectToAction("Index", "Home"); // Wróć do dashboardu
+                return RedirectToAction("Index", "Home");
             }
-            // Jeśli model nie jest poprawny, wróć do formularza z błędami
             return View(zadanie);
         }
 
 
-        // POST: Zadania/Delete/5 (dla usuwania zadania)
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Delete(int id)
@@ -138,18 +125,11 @@ namespace Intranet.Controllers
                 return Unauthorized("Nie można zidentyfikować użytkownika.");
             }
 
-            // Tylko właściciel zadania lub admin może je usunąć
             if (zadanie.PracownikId != currentUserId && !User.IsInRole("Admin"))
             {
                 return Forbid("Nie masz uprawnień do usunięcia tego zadania.");
             }
 
-            // Dodatkowa logika: np. pozwól usuwać tylko wykonane zadania
-            // if (!zadanie.CzyWykonane && !User.IsInRole("Admin"))
-            // {
-            //     TempData["ErrorMessage"] = "Można usuwać tylko wykonane zadania.";
-            //     return RedirectToAction("Index", "Home");
-            // }
 
             _context.Zadania.Remove(zadanie);
             await _context.SaveChangesAsync();

--- a/Intranet/Controllers/ZamowieniaController.cs
+++ b/Intranet/Controllers/ZamowieniaController.cs
@@ -3,11 +3,9 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System.Linq;
 using System.Threading.Tasks;
-// using Microsoft.AspNetCore.Authorization;
 
 namespace Intranet.Controllers
 {
-    // [Authorize] 
     public class ZamowieniaController : Controller
     {
         private readonly IntranetContext _context;
@@ -78,9 +76,6 @@ namespace Intranet.Controllers
             {
                 try
                 {
-                    // Rozważ pobranie oryginalnego obiektu i aktualizację tylko wybranych pól,
-                    // jeśli nie wszystkie pola z [Bind] mają być edytowalne lub jeśli chcesz
-                    // zachować pewne wartości (np. oryginalną DataZlozenia, jeśli nie jest readonly w formularzu).
                     _context.Update(zamowienie);
                     await _context.SaveChangesAsync();
                     TempData["SuccessMessage"] = "Zamówienie zostało zaktualizowane.";
@@ -94,12 +89,12 @@ namespace Intranet.Controllers
                     else
                     {
                         ModelState.AddModelError(string.Empty, "Wystąpił błąd współbieżności. Spróbuj ponownie.");
-                        return View(zamowienie); // Wróć do widoku z błędem
+                        return View(zamowienie);
                     }
                 }
                 return RedirectToAction(nameof(Index));
             }
-            return View(zamowienie); // Wróć do widoku z błędami walidacji
+            return View(zamowienie);
         }
 
         private bool ZamowienieExists(int id)

--- a/Portal/Controllers/CartController.cs
+++ b/Portal/Controllers/CartController.cs
@@ -3,9 +3,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using FashionStore.Models;                    // CartPageViewModel, CheckoutFormModel
-using Intranet.Models;                        // Zamowienie, PozycjaZamowienia, StatusZamowienia, IntranetContext
-using Portal.Services;                        // ICartService, IProductService
+using FashionStore.Models;
+using Intranet.Models;
+using Portal.Services;
 
 namespace FashionStore.Controllers
 {
@@ -74,7 +74,6 @@ namespace FashionStore.Controllers
         {
             var model = new CheckoutFormModel();
 
-            // Prefill, jeśli użytkownik zalogowany
             var uid = HttpContext.Session.GetInt32("UserId");
             if (uid is not null)
             {

--- a/Portal/Controllers/SearchController.cs
+++ b/Portal/Controllers/SearchController.cs
@@ -10,9 +10,6 @@ namespace Portal.Controllers
 
         public SearchController(IProductService products) => _products = products;
 
-        /// <summary>
-        /// Pełnotekstowe wyszukiwanie produktów z opcjonalnym filtrowaniem
-        /// </summary>
         public async Task<IActionResult> Index(
             string? q,
             string? category,

--- a/Portal/Models/ErrorViewModel.cs
+++ b/Portal/Models/ErrorViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace Portal.Models // Poprawna przestrzeń nazw
+﻿namespace Portal.Models
 {
     public class ErrorViewModel
     {

--- a/Portal/Program.cs
+++ b/Portal/Program.cs
@@ -6,7 +6,6 @@ using Portal.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// ────────────── SERWISY ──────────────
 builder.Services.AddDbContext<IntranetContext>(opts =>
     opts.UseSqlServer(builder.Configuration.GetConnectionString("IntranetDb")));
 
@@ -18,7 +17,6 @@ builder.Services.AddScoped<PortalTextService>();
 builder.Services.AddScoped<IProductService, ProductService>();
 builder.Services.AddScoped<ICartService, CartService>();
 
-// ────────────── MVC – usuń kontrolery z assembly „Intranet” ──────────────
 builder.Services.AddControllersWithViews()
     .ConfigureApplicationPartManager(apm =>
     {
@@ -33,7 +31,6 @@ builder.Services.AddControllersWithViews()
 
 var app = builder.Build();
 
-// ────────────── PIPELINE ──────────────
 if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/Home/Error");
@@ -49,7 +46,7 @@ app.UseStaticFiles();
 
 app.UseRouting();
 
-app.UseSession();   // sesje przed autoryzacją
+app.UseSession();
 app.UseAuthorization();
 
 app.MapControllerRoute(

--- a/Portal/Services/IProductService.cs
+++ b/Portal/Services/IProductService.cs
@@ -6,13 +6,11 @@ public interface IProductService
     Task<List<FashionStore.Models.ProductModel>> GetByCategoryAsync(string category);
     Task<List<FashionStore.Models.ProductModel>> GetRandomAsync(int count);
 
-    // Rozszerzone wyszukiwanie (query + filtry)
     Task<List<FashionStore.Models.ProductModel>> SearchAsync(
         string? query,
         string? category = null,
         decimal? minPrice = null,
         decimal? maxPrice = null);
 
-    // Lista dostępnych kategorii (np. do dropdownu w wyszukiwarce)
     Task<List<string>> GetCategoriesAsync();
 }

--- a/Portal/TagHelpers/PortalTextTagHelper.cs
+++ b/Portal/TagHelpers/PortalTextTagHelper.cs
@@ -19,6 +19,6 @@ public class PortalTextTagHelper : TagHelper
     public override void Process(TagHelperContext context, TagHelperOutput output)
     {
         var value = _service.Get(Key);
-        output.Content.SetContent(value);
+        output.Content.SetHtmlContent(value);
     }
 }

--- a/Portal/Views/Cart/Checkout.cshtml
+++ b/Portal/Views/Cart/Checkout.cshtml
@@ -3,7 +3,6 @@
     ViewData["Title"] = "Finalizacja zamówienia";
 }
 
-<!-- ────────────── HERO ────────────── -->
 <div class="relative h-[40vh] overflow-hidden">
     <div class="absolute inset-0 z-0">
         <div class="absolute inset-0 bg-gradient-to-r from-black/70 to-black/30 z-10"></div>
@@ -17,7 +16,6 @@
     </div>
 </div>
 
-<!-- ────────────── CHECKOUT FORM ────────────── -->
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">
     <div class="max-w-xl mx-auto">
         <form asp-action="Checkout" method="post" class="space-y-6">

--- a/Portal/Views/Cart/Index.cshtml
+++ b/Portal/Views/Cart/Index.cshtml
@@ -19,7 +19,6 @@
 }
 
 <div class="cart-page">
-    <!-- Hero section z asymetrycznym układem -->
     <section class="relative h-[40vh] overflow-hidden">
         <div class="absolute inset-0 z-0">
             <div class="absolute inset-0 bg-gradient-to-r from-black/70 to-black/30 z-10"></div>
@@ -39,12 +38,10 @@
         </div>
     </section>
 
-    <!-- Zawartość koszyka -->
     <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">
         <div class="max-w-7xl mx-auto">
             @if (Model.Items.Count == 0)
             {
-                <!-- Pusty koszyk -->
                 <div class="flex flex-col items-center justify-center py-20">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-24 w-24 text-gray-300 mb-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" />
@@ -58,27 +55,22 @@
             }
             else
             {
-                <!-- Koszyk z produktami -->
                 <div class="grid grid-cols-1 lg:grid-cols-3 gap-12">
-                    <!-- Lewa kolumna - lista produktów -->
                     <div class="lg:col-span-2">
                         <div class="mb-8 flex justify-between items-center">
                             <h2 class="text-3xl font-light">PRODUKTY</h2>
                             <span class="text-gray-500">@Model.Items.Count @(Model.Items.Count == 1 ? "produkt" : Model.Items.Count < 5 ? "produkty" : "produktów")</span>
                         </div>
 
-                        <!-- Lista produktów -->
                         <div class="space-y-8">
                             @foreach (var item in Model.Items)
                             {
                                 <div class="cart-item group relative overflow-hidden" data-item-id="@item.Id">
                                     <div class="grid grid-cols-1 md:grid-cols-5 gap-6 items-center">
-                                        <!-- Zdjęcie produktu -->
                                         <div class="md:col-span-2 relative aspect-[3/2] overflow-hidden">
                                             <img src="@item.ImageUrl" alt="@item.Name" class="w-full h-full object-cover object-center transition-transform duration-700 group-hover:scale-105">
                                         </div>
 
-                                        <!-- Informacje o produkcie -->
                                         <div class="md:col-span-3 flex flex-col md:flex-row md:items-center md:justify-between w-full">
                                             <div class="mb-4 md:mb-0">
                                                 <h3 class="text-xl font-medium mb-1">@item.Name</h3>
@@ -91,7 +83,6 @@
                                             </div>
 
                                             <div class="flex items-center space-x-6">
-                                                <!-- Kontrolka ilości -->
                                                 <div class="flex items-center border border-gray-300">
                                                     <button class="quantity-decrease px-3 py-2 hover:bg-gray-100 transition-colors">
                                                         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -106,7 +97,6 @@
                                                     </button>
                                                 </div>
 
-                                                <!-- Przycisk usuwania -->
                                                 <button class="remove-item text-gray-400 hover:text-black transition-colors">
                                                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
@@ -116,13 +106,11 @@
                                         </div>
                                     </div>
 
-                                    <!-- Linia oddzielająca -->
                                     <div class="mt-8 border-b border-gray-200"></div>
                                 </div>
                             }
                         </div>
 
-                        <!-- Przyciski nawigacyjne -->
                         <div class="mt-12 flex flex-col sm:flex-row justify-between items-center">
                             <a href="/" class="inline-flex items-center text-black hover:underline mb-4 sm:mb-0">
                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -140,19 +128,16 @@
                         </div>
                     </div>
 
-                    <!-- Prawa kolumna - podsumowanie -->
                     <div class="lg:col-span-1">
                         <div class="sticky top-32">
                             <div class="bg-gray-50 p-8">
                                 <h2 class="text-3xl font-light mb-8">PODSUMOWANIE</h2>
 
-                                <!-- Wartość produktów -->
                                 <div class="flex justify-between mb-4">
                                     <span class="text-gray-600">Wartość produktów</span>
                                     <span class="font-medium">@subtotal.ToString("0.00") zł</span>
                                 </div>
 
-                                <!-- Dostawa -->
                                 <div class="flex justify-between mb-4">
                                     <span class="text-gray-600">Dostawa</span>
                                     @if (shipping > 0)
@@ -165,7 +150,6 @@
                                     }
                                 </div>
 
-                                <!-- Rabat -->
                                 @if (discount > 0)
                                 {
                                     <div class="flex justify-between mb-4">
@@ -174,16 +158,13 @@
                                     </div>
                                 }
 
-                                <!-- Linia oddzielająca -->
                                 <div class="border-t border-gray-300 my-6"></div>
 
-                                <!-- Suma -->
                                 <div class="flex justify-between mb-8">
                                     <span class="text-xl font-medium">Suma</span>
                                     <span class="text-xl font-medium">@total.ToString("0.00") zł</span>
                                 </div>
 
-                                <!-- Kod rabatowy -->
                                 <div class="mb-8">
                                     <div class="flex">
                                         <input type="text" id="discount-code" placeholder="Kod rabatowy" class="flex-grow px-4 py-3 border border-gray-300 focus:outline-none focus:border-black">
@@ -193,19 +174,16 @@
                                     </div>
                                 </div>
 
-                                <!-- Przycisk do płatności -->
                                 <a href="/Cart/Checkout" class="block w-full px-8 py-4 bg-black text-white font-medium text-center hover:bg-gray-800 transition-colors">
                                     PRZEJDŹ DO PŁATNOŚCI
                                 </a>
 
-                                <!-- Informacje dodatkowe -->
                                 <div class="mt-6 text-sm text-gray-500">
                                     <p class="mb-2">Darmowa dostawa dla zamówień powyżej 500 zł.</p>
                                     <p>Możliwość zwrotu w ciągu 14 dni.</p>
                                 </div>
                             </div>
 
-                            <!-- Metody płatności -->
                             <div class="mt-8 flex justify-center space-x-4">
                                 <img src="/images/payment-visa.svg" alt="Visa" class="h-6">
                                 <img src="/images/payment-mastercard.svg" alt="Mastercard" class="h-6">
@@ -219,7 +197,6 @@
         </div>
     </section>
 
-    <!-- Sekcja z rekomendacjami -->
     <section class="py-16 px-6 md:px-12 lg:px-24 bg-gray-50">
         <div class="max-w-7xl mx-auto">
             <h2 class="text-3xl font-light mb-12 text-center">MOŻE CIĘ ZAINTERESOWAĆ</h2>

--- a/Portal/Views/Cart/Success.cshtml
+++ b/Portal/Views/Cart/Success.cshtml
@@ -3,7 +3,6 @@
     ViewData["Title"] = "Dziękujemy za zakupy";
 }
 
-<!-- ────────────── HERO ────────────── -->
 <div class="relative h-[40vh] overflow-hidden">
     <div class="absolute inset-0 z-0">
         <div class="absolute inset-0 bg-gradient-to-r from-black/70 to-black/30 z-10"></div>
@@ -17,7 +16,6 @@
     </div>
 </div>
 
-<!-- ────────────── PODZIĘKOWANIE ────────────── -->
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10 text-center">
     <div class="max-w-xl mx-auto space-y-6">
         <p class="text-lg">

--- a/Portal/Views/Category/Accessories.cshtml
+++ b/Portal/Views/Category/Accessories.cshtml
@@ -4,7 +4,6 @@
 }
 
 <div class="category-page accessories-category-page">
-    <!-- Hero section z asymetrycznym układem -->
     <section class="relative h-[70vh] overflow-hidden">
         <div class="absolute inset-0 z-0">
             <div class="absolute inset-0 bg-gradient-to-r from-black/70 to-black/30 z-10"></div>
@@ -33,10 +32,8 @@
         </div>
     </section>
 
-    <!-- Filtry i produkty w asymetrycznym układzie -->
     <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">
         <div class="max-w-7xl mx-auto">
-            <!-- Nagłówek z licznikiem produktów i sortowaniem -->
             <div class="flex flex-col md:flex-row justify-between items-start md:items-center mb-12">
                 <div class="mb-4 md:mb-0">
                     <h2 class="text-3xl font-light">KOLEKCJA</h2>
@@ -80,10 +77,8 @@
                 </div>
             </div>
 
-            <!-- Panel filtrów - domyślnie ukryty -->
             <div id="filter-panel" class="mb-12 hidden">
                 <div class="grid grid-cols-1 md:grid-cols-4 gap-8 p-8 bg-gray-50">
-                    <!-- Kategorie -->
                     <div>
                         <h3 class="font-medium mb-4">KATEGORIE</h3>
                         <div class="space-y-2">
@@ -114,7 +109,6 @@
                         </div>
                     </div>
 
-                    <!-- Materiały -->
                     <div>
                         <h3 class="font-medium mb-4">MATERIAŁ</h3>
                         <div class="space-y-2">
@@ -141,7 +135,6 @@
                         </div>
                     </div>
 
-                    <!-- Kolory -->
                     <div>
                         <h3 class="font-medium mb-4">KOLOR</h3>
                         <div class="flex flex-wrap gap-3">
@@ -156,7 +149,6 @@
                         </div>
                     </div>
 
-                    <!-- Cena -->
                     <div>
                         <h3 class="font-medium mb-4">CENA</h3>
                         <div class="px-2">
@@ -180,7 +172,6 @@
                 </div>
             </div>
 
-            <!-- Asymetryczna siatka produktów -->
             <div class="asymmetric-grid">
                 @{
                     // Wyróżnione produkty (większe kafelki)
@@ -189,9 +180,7 @@
                     var regularProducts = Model.Where(p => !p.Featured || !featuredProducts.Contains(p)).ToList();
                 }
 
-                <!-- Pierwszy rząd - asymetryczny -->
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12">
-                    <!-- Duży produkt po lewej -->
                     @if (featuredProducts.Count > 0)
                     {
                         var product = featuredProducts[0];
@@ -241,7 +230,6 @@
                         </div>
                     }
 
-                    <!-- Mniejszy produkt po prawej -->
                     @if (featuredProducts.Count > 1)
                     {
                         var product = featuredProducts[1];
@@ -292,9 +280,7 @@
                     }
                 </div>
 
-                <!-- Drugi rząd - asymetryczny w drugą stronę -->
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12">
-                    <!-- Mniejszy produkt po lewej -->
                     @if (featuredProducts.Count > 2)
                     {
                         var product = featuredProducts[2];
@@ -344,7 +330,6 @@
                         </div>
                     }
 
-                    <!-- Duży produkt po prawej -->
                     @if (featuredProducts.Count > 3)
                     {
                         var product = featuredProducts[3];
@@ -395,7 +380,6 @@
                     }
                 </div>
 
-                <!-- Pozostałe produkty w asymetrycznej siatce -->
                 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
                     @foreach (var product in regularProducts)
                     {
@@ -447,7 +431,6 @@
                 </div>
             </div>
 
-            <!-- Paginacja -->
             <div class="mt-16 flex justify-center">
                 <div class="flex items-center space-x-2">
                     <a href="#" class="w-10 h-10 flex items-center justify-center border border-gray-300 hover:border-black transition-colors">
@@ -470,7 +453,6 @@
         </div>
     </section>
 
-    <!-- Sekcja z trendem sezonu - asymetryczna -->
     <section class="py-20 relative overflow-hidden">
         <div class="absolute top-0 left-0 w-1/2 h-full bg-gray-100 z-0"></div>
         <div class="absolute top-0 right-0 w-1/2 h-full bg-black z-0"></div>
@@ -497,7 +479,6 @@
         </div>
     </section>
 
-    <!-- Newsletter -->
     <section class="py-20 px-6 md:px-12 lg:px-24 bg-gray-100">
         <div class="max-w-7xl mx-auto">
             <div class="flex flex-col md:flex-row md:items-center md:justify-between">

--- a/Portal/Views/Category/Kids.cshtml
+++ b/Portal/Views/Category/Kids.cshtml
@@ -4,7 +4,6 @@
 }
 
 <div class="category-page kids-category-page">
-    <!-- Hero section z asymetrycznym układem -->
     <section class="relative h-[70vh] overflow-hidden">
         <div class="absolute inset-0 z-0">
             <div class="absolute inset-0 bg-gradient-to-r from-black/70 to-black/30 z-10"></div>
@@ -33,10 +32,8 @@
         </div>
     </section>
 
-    <!-- Filtry i produkty w asymetrycznym układzie -->
     <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">
         <div class="max-w-7xl mx-auto">
-            <!-- Nagłówek z licznikiem produktów i sortowaniem -->
             <div class="flex flex-col md:flex-row justify-between items-start md:items-center mb-12">
                 <div class="mb-4 md:mb-0">
                     <h2 class="text-3xl font-light">KOLEKCJA</h2>
@@ -80,10 +77,8 @@
                 </div>
             </div>
 
-            <!-- Panel filtrów - domyślnie ukryty -->
             <div id="filter-panel" class="mb-12 hidden">
                 <div class="grid grid-cols-1 md:grid-cols-4 gap-8 p-8 bg-gray-50">
-                    <!-- Kategorie -->
                     <div>
                         <h3 class="font-medium mb-4">KATEGORIE</h3>
                         <div class="space-y-2">
@@ -114,7 +109,6 @@
                         </div>
                     </div>
 
-                    <!-- Rozmiary -->
                     <div>
                         <h3 class="font-medium mb-4">ROZMIAR</h3>
                         <div class="grid grid-cols-3 gap-2">
@@ -127,7 +121,6 @@
                         </div>
                     </div>
 
-                    <!-- Kolory -->
                     <div>
                         <h3 class="font-medium mb-4">KOLOR</h3>
                         <div class="flex flex-wrap gap-3">
@@ -141,7 +134,6 @@
                         </div>
                     </div>
 
-                    <!-- Cena -->
                     <div>
                         <h3 class="font-medium mb-4">CENA</h3>
                         <div class="px-2">
@@ -165,7 +157,6 @@
                 </div>
             </div>
 
-            <!-- Asymetryczna siatka produktów -->
             <div class="asymmetric-grid">
                 @{
                     // Wyróżnione produkty (większe kafelki)
@@ -174,9 +165,7 @@
                     var regularProducts = Model.Where(p => !p.Featured || !featuredProducts.Contains(p)).ToList();
                 }
 
-                <!-- Pierwszy rząd - asymetryczny -->
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12">
-                    <!-- Duży produkt po lewej -->
                     @if (featuredProducts.Count > 0)
                     {
                         var product = featuredProducts[0];
@@ -226,7 +215,6 @@
                         </div>
                     }
 
-                    <!-- Mniejszy produkt po prawej -->
                     @if (featuredProducts.Count > 1)
                     {
                         var product = featuredProducts[1];
@@ -277,9 +265,7 @@
                     }
                 </div>
 
-                <!-- Drugi rząd - asymetryczny w drugą stronę -->
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12">
-                    <!-- Mniejszy produkt po lewej -->
                     @if (featuredProducts.Count > 2)
                     {
                         var product = featuredProducts[2];
@@ -329,7 +315,6 @@
                         </div>
                     }
 
-                    <!-- Duży produkt po prawej -->
                     @if (featuredProducts.Count > 3)
                     {
                         var product = featuredProducts[3];
@@ -380,7 +365,6 @@
                     }
                 </div>
 
-                <!-- Pozostałe produkty w asymetrycznej siatce -->
                 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
                     @foreach (var product in regularProducts)
                     {
@@ -432,7 +416,6 @@
                 </div>
             </div>
 
-            <!-- Paginacja -->
             <div class="mt-16 flex justify-center">
                 <div class="flex items-center space-x-2">
                     <a href="#" class="w-10 h-10 flex items-center justify-center border border-gray-300 hover:border-black transition-colors">
@@ -455,7 +438,6 @@
         </div>
     </section>
 
-    <!-- Sekcja z trendem sezonu - asymetryczna -->
     <section class="py-20 relative overflow-hidden">
         <div class="absolute top-0 left-0 w-1/2 h-full bg-gray-100 z-0"></div>
         <div class="absolute top-0 right-0 w-1/2 h-full bg-black z-0"></div>
@@ -482,7 +464,6 @@
         </div>
     </section>
 
-    <!-- Newsletter -->
     <section class="py-20 px-6 md:px-12 lg:px-24 bg-gray-100">
         <div class="max-w-7xl mx-auto">
             <div class="flex flex-col md:flex-row md:items-center md:justify-between">

--- a/Portal/Views/Category/Men.cshtml
+++ b/Portal/Views/Category/Men.cshtml
@@ -4,7 +4,6 @@
 }
 
 <div class="category-page men-category-page">
-    <!-- Hero section z asymetrycznym układem -->
     <section class="relative h-[70vh] overflow-hidden">
         <div class="absolute inset-0 z-0">
             <div class="absolute inset-0 bg-gradient-to-r from-black/70 to-black/30 z-10"></div>
@@ -33,10 +32,8 @@
         </div>
     </section>
 
-    <!-- Filtry i produkty w asymetrycznym układzie -->
     <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">
         <div class="max-w-7xl mx-auto">
-            <!-- Nagłówek z licznikiem produktów i sortowaniem -->
             <div class="flex flex-col md:flex-row justify-between items-start md:items-center mb-12">
                 <div class="mb-4 md:mb-0">
                     <h2 class="text-3xl font-light">KOLEKCJA</h2>
@@ -80,10 +77,8 @@
                 </div>
             </div>
 
-            <!-- Panel filtrów - domyślnie ukryty -->
             <div id="filter-panel" class="mb-12 hidden">
                 <div class="grid grid-cols-1 md:grid-cols-4 gap-8 p-8 bg-gray-50">
-                    <!-- Kategorie -->
                     <div>
                         <h3 class="font-medium mb-4">KATEGORIE</h3>
                         <div class="space-y-2">
@@ -114,7 +109,6 @@
                         </div>
                     </div>
 
-                    <!-- Rozmiary -->
                     <div>
                         <h3 class="font-medium mb-4">ROZMIAR</h3>
                         <div class="grid grid-cols-3 gap-2">
@@ -127,7 +121,6 @@
                         </div>
                     </div>
 
-                    <!-- Kolory -->
                     <div>
                         <h3 class="font-medium mb-4">KOLOR</h3>
                         <div class="flex flex-wrap gap-3">
@@ -141,7 +134,6 @@
                         </div>
                     </div>
 
-                    <!-- Cena -->
                     <div>
                         <h3 class="font-medium mb-4">CENA</h3>
                         <div class="px-2">
@@ -165,7 +157,6 @@
                 </div>
             </div>
 
-            <!-- Asymetryczna siatka produktów -->
             <div class="asymmetric-grid">
                 @{
                     // Wyróżnione produkty (większe kafelki)
@@ -174,9 +165,7 @@
                     var regularProducts = Model.Where(p => !p.Featured || !featuredProducts.Contains(p)).ToList();
                 }
 
-                <!-- Pierwszy rząd - asymetryczny -->
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12">
-                    <!-- Duży produkt po lewej -->
                     @if (featuredProducts.Count > 0)
                     {
                         var product = featuredProducts[0];
@@ -226,7 +215,6 @@
                         </div>
                     }
 
-                    <!-- Mniejszy produkt po prawej -->
                     @if (featuredProducts.Count > 1)
                     {
                         var product = featuredProducts[1];
@@ -277,9 +265,7 @@
                     }
                 </div>
 
-                <!-- Drugi rząd - asymetryczny w drugą stronę -->
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12">
-                    <!-- Mniejszy produkt po lewej -->
                     @if (featuredProducts.Count > 2)
                     {
                         var product = featuredProducts[2];
@@ -329,7 +315,6 @@
                         </div>
                     }
 
-                    <!-- Duży produkt po prawej -->
                     @if (featuredProducts.Count > 3)
                     {
                         var product = featuredProducts[3];
@@ -380,7 +365,6 @@
                     }
                 </div>
 
-                <!-- Pozostałe produkty w asymetrycznej siatce -->
                 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
                     @foreach (var product in regularProducts)
                     {
@@ -432,7 +416,6 @@
                 </div>
             </div>
 
-            <!-- Paginacja -->
             <div class="mt-16 flex justify-center">
                 <div class="flex items-center space-x-2">
                     <a href="#" class="w-10 h-10 flex items-center justify-center border border-gray-300 hover:border-black transition-colors">
@@ -455,7 +438,6 @@
         </div>
     </section>
 
-    <!-- Sekcja z trendem sezonu - asymetryczna -->
     <section class="py-20 relative overflow-hidden">
         <div class="absolute top-0 left-0 w-1/2 h-full bg-gray-100 z-0"></div>
         <div class="absolute top-0 right-0 w-1/2 h-full bg-black z-0"></div>
@@ -483,7 +465,6 @@
         </div>
     </section>
 
-    <!-- Newsletter -->
     <section class="py-20 px-6 md:px-12 lg:px-24 bg-gray-100">
         <div class="max-w-7xl mx-auto">
             <div class="flex flex-col md:flex-row md:items-center md:justify-between">

--- a/Portal/Views/Category/Women.cshtml
+++ b/Portal/Views/Category/Women.cshtml
@@ -4,7 +4,6 @@
 }
 
 <div class="women-category-page">
-    <!-- Hero section z asymetrycznym układem -->
     <section class="relative h-[70vh] overflow-hidden">
         <div class="absolute inset-0 z-0">
             <div class="absolute inset-0 bg-gradient-to-r from-black/70 to-black/30 z-10"></div>
@@ -33,10 +32,8 @@
         </div>
     </section>
 
-    <!-- Filtry i produkty w asymetrycznym układzie -->
     <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">
         <div class="max-w-7xl mx-auto">
-            <!-- Nagłówek z licznikiem produktów i sortowaniem -->
             <div class="flex flex-col md:flex-row justify-between items-start md:items-center mb-12">
                 <div class="mb-4 md:mb-0">
                     <h2 class="text-3xl font-light">KOLEKCJA</h2>
@@ -80,10 +77,8 @@
                 </div>
             </div>
 
-            <!-- Panel filtrów - domyślnie ukryty -->
             <div id="filter-panel" class="mb-12 hidden">
                 <div class="grid grid-cols-1 md:grid-cols-4 gap-8 p-8 bg-gray-50">
-                    <!-- Kategorie -->
                     <div>
                         <h3 class="font-medium mb-4">KATEGORIE</h3>
                         <div class="space-y-2">
@@ -114,7 +109,6 @@
                         </div>
                     </div>
 
-                    <!-- Rozmiary -->
                     <div>
                         <h3 class="font-medium mb-4">ROZMIAR</h3>
                         <div class="grid grid-cols-3 gap-2">
@@ -127,7 +121,6 @@
                         </div>
                     </div>
 
-                    <!-- Kolory -->
                     <div>
                         <h3 class="font-medium mb-4">KOLOR</h3>
                         <div class="flex flex-wrap gap-3">
@@ -144,7 +137,6 @@
                         </div>
                     </div>
 
-                    <!-- Cena -->
                     <div>
                         <h3 class="font-medium mb-4">CENA</h3>
                         <div class="px-2">
@@ -168,7 +160,6 @@
                 </div>
             </div>
 
-            <!-- Asymetryczna siatka produktów -->
             <div class="asymmetric-grid">
                 @{
                     // Wyróżnione produkty (większe kafelki)
@@ -177,9 +168,7 @@
                     var regularProducts = Model.Where(p => !p.Featured || !featuredProducts.Contains(p)).ToList();
                 }
 
-                <!-- Pierwszy rząd - asymetryczny -->
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12">
-                    <!-- Duży produkt po lewej -->
                     @if (featuredProducts.Count > 0)
                     {
                         var product = featuredProducts[0];
@@ -229,7 +218,6 @@
                         </div>
                     }
 
-                    <!-- Mniejszy produkt po prawej -->
                     @if (featuredProducts.Count > 1)
                     {
                         var product = featuredProducts[1];
@@ -280,9 +268,7 @@
                     }
                 </div>
 
-                <!-- Drugi rząd - asymetryczny w drugą stronę -->
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12">
-                    <!-- Mniejszy produkt po lewej -->
                     @if (featuredProducts.Count > 2)
                     {
                         var product = featuredProducts[2];
@@ -332,7 +318,6 @@
                         </div>
                     }
 
-                    <!-- Duży produkt po prawej -->
                     @if (featuredProducts.Count > 3)
                     {
                         var product = featuredProducts[3];
@@ -383,7 +368,6 @@
                     }
                 </div>
 
-                <!-- Pozostałe produkty w asymetrycznej siatce -->
                 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
                     @foreach (var product in regularProducts)
                     {
@@ -435,7 +419,6 @@
                 </div>
             </div>
 
-            <!-- Paginacja -->
             <div class="mt-16 flex justify-center">
                 <div class="flex items-center space-x-2">
                     <a href="#" class="w-10 h-10 flex items-center justify-center border border-gray-300 hover:border-black transition-colors">
@@ -458,7 +441,6 @@
         </div>
     </section>
 
-    <!-- Sekcja z trendem sezonu - asymetryczna -->
     <section class="py-20 relative overflow-hidden">
         <div class="absolute top-0 left-0 w-1/2 h-full bg-gray-100 z-0"></div>
         <div class="absolute top-0 right-0 w-1/2 h-full bg-black z-0"></div>
@@ -486,7 +468,6 @@
         </div>
     </section>
 
-    <!-- Newsletter -->
     <section class="py-20 px-6 md:px-12 lg:px-24 bg-gray-100">
         <div class="max-w-7xl mx-auto">
             <div class="flex flex-col md:flex-row md:items-center md:justify-between">

--- a/Portal/Views/Home/Error.cshtml
+++ b/Portal/Views/Home/Error.cshtml
@@ -1,25 +1,25 @@
-﻿@model Portal.Models.ErrorViewModel
+@model Portal.Models.ErrorViewModel
 @{
-    ViewData["Title"] = "Error";
+    ViewData["Title"] = "Błąd";
 }
 
-<h1 class="text-danger">Error.</h1>
-<h2 class="text-danger">An error occurred while processing your request.</h2>
+<h1 class="text-danger">Błąd.</h1>
+<h2 class="text-danger">Wystąpił błąd podczas przetwarzania żądania.</h2>
 
 @if (Model.ShowRequestId)
 {
     <p>
-        <strong>Request ID:</strong> <code>@Model.RequestId</code>
+        <strong>Identyfikator żądania:</strong> <code>@Model.RequestId</code>
     </p>
 }
 
-<h3>Development Mode</h3>
+<h3>Tryb deweloperski</h3>
 <p>
-    Swapping to the <strong>Development</strong> environment displays detailed information about the error that occurred.
+    Włączenie środowiska <strong>Development</strong> pozwala zobaczyć szczegółowe informacje o błędzie.
 </p>
 <p>
-    <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
-    It can result in displaying sensitive information from exceptions to end users.
-    For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
-    and restarting the app.
+    <strong>Środowisko Development nie powinno być włączone na środowisku produkcyjnym.</strong>
+    Może to ujawnić wrażliwe informacje użytkownikom końcowym.
+    Do lokalnego debugowania ustaw zmienną środowiskową <strong>ASPNETCORE_ENVIRONMENT</strong>
+    na wartość <strong>Development</strong> i zrestartuj aplikację.
 </p>

--- a/Portal/Views/Home/Index.cshtml
+++ b/Portal/Views/Home/Index.cshtml
@@ -5,7 +5,6 @@
 }
 
 <div class="relative overflow-hidden">
-    <!-- ────────────── HERO ────────────── -->
     <div class="relative h-screen overflow-hidden">
         <div class="absolute inset-0 z-0">
             <div class="absolute inset-0 bg-gradient-to-r from-black/70 to-black/30 z-10"></div>
@@ -41,7 +40,6 @@
         </div>
     </div>
 
-    <!-- ────────────── KATEGORIE ────────────── -->
     <section id="categories" class="py-20 px-6 md:px-12 lg:px-24 bg-white relative z-10">
         <div class="max-w-7xl mx-auto">
             <div class="flex flex-col items-center mb-16">
@@ -83,7 +81,6 @@
         </div>
     </section>
 
-    <!-- ────────────── WYRÓŻNIONE PRODUKTY ────────────── -->
     <section id="featured" class="py-20 px-6 md:px-12 lg:px-24 bg-gray-50 relative z-10">
         <div class="max-w-7xl mx-auto">
             <div class="flex flex-col items-center mb-16">
@@ -105,7 +102,6 @@
                                  class="w-full h-full object-cover object-center
                                         transition-transform duration-700 group-hover:scale-105" />
 
-                            <!-- Badge -->
                             @if (product.IsNew)
                             {
                                 <div class="absolute top-4 right-4 bg-black text-white text-xs px-3 py-1 font-medium">
@@ -160,7 +156,6 @@
         </div>
     </section>
 
-    <!-- ────────────── LOOKBOOK ────────────── -->
     <section id="lookbook" class="relative h-screen flex items-center overflow-hidden">
         <div class="absolute inset-0 bg-cover bg-center lookbook-bg"
              style="background-image: url('/images/lookbook.jpg');"></div>
@@ -181,7 +176,6 @@
         </div>
     </section>
 
-    <!-- ────────────── NEWSLETTER ────────────── -->
     <section id="newsletter" class="py-20 px-6 md:px-12 lg:px-24 bg-black text-white relative z-10">
         <div class="max-w-7xl mx-auto">
             <div class="flex flex-col md:flex-row md:items-center md:justify-between">
@@ -212,7 +206,6 @@
         </div>
     </section>
 
-    <!-- ────────────── INSTAGRAM FEED ────────────── -->
     <section id="instagram" class="py-20 px-6 md:px-12 lg:px-24 bg-white relative z-10">
         <div class="max-w-7xl mx-auto">
             <div class="flex flex-col items-center mb-16">

--- a/Portal/Views/Info/About.cshtml
+++ b/Portal/Views/Info/About.cshtml
@@ -12,7 +12,7 @@
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">
     <div class="max-w-3xl mx-auto text-gray-700 space-y-4">
-        <p>CIUCHY to marka łącząca pasję do mody z wysoką jakością wykonania. Tworzymy ubrania, które pozwalają wyrazić indywidualny styl.</p>
-        <p>Nasz zespół dba o każdy detal, dzięki czemu oferujemy kolekcje dopracowane i zgodne z najnowszymi trendami.</p>
+        <p portal-text="Info_About_Text1"></p>
+        <p portal-text="Info_About_Text2"></p>
     </div>
 </section>

--- a/Portal/Views/Info/Contact.cshtml
+++ b/Portal/Views/Info/Contact.cshtml
@@ -12,7 +12,7 @@
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">
     <div class="max-w-3xl mx-auto text-gray-700 space-y-4">
-        <p>Masz pytania? Skontaktuj się z nami pod adresem <strong>kontakt@ciuchy.pl</strong> lub telefonicznie: <strong>+48 123 456 789</strong>.</p>
-        <p>Odpowiadamy na wiadomości w dni robocze w godzinach 9:00-17:00.</p>
+        <p portal-text="Info_Contact_Text1"></p>
+        <p portal-text="Info_Contact_Text2"></p>
     </div>
 </section>

--- a/Portal/Views/Info/Faq.cshtml
+++ b/Portal/Views/Info/Faq.cshtml
@@ -12,7 +12,7 @@
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">
     <div class="max-w-3xl mx-auto text-gray-700 space-y-4">
-        <p>Najczęściej zadawane pytania dotyczące zakupów w naszym sklepie znajdziesz poniżej.</p>
-        <p>Jeśli nie znalazłeś odpowiedzi, napisz do nas – chętnie pomożemy.</p>
+        <p portal-text="Info_Faq_Text1"></p>
+        <p portal-text="Info_Faq_Text2"></p>
     </div>
 </section>

--- a/Portal/Views/Info/Jobs.cshtml
+++ b/Portal/Views/Info/Jobs.cshtml
@@ -12,7 +12,7 @@
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">
     <div class="max-w-3xl mx-auto text-gray-700 space-y-4">
-        <p>Szukasz inspirującego miejsca pracy? W CIUCHY stawiamy na kreatywność i rozwój. Regularnie poszukujemy osób pełnych pasji do mody.</p>
-        <p>Wyślij swoje CV na adres <strong>praca@ciuchy.pl</strong> i dołącz do naszego zespołu.</p>
+        <p portal-text="Info_Jobs_Text1"></p>
+        <p portal-text="Info_Jobs_Text2"></p>
     </div>
 </section>

--- a/Portal/Views/Info/Privacy.cshtml
+++ b/Portal/Views/Info/Privacy.cshtml
@@ -12,7 +12,7 @@
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">
     <div class="max-w-3xl mx-auto text-gray-700 space-y-4">
-        <p>Chronimy Twoje dane osobowe i przetwarzamy je zgodnie z obowiązującymi przepisami. Szczegóły dotyczące przetwarzania danych znajdziesz poniżej.</p>
-        <p>W razie pytań dotyczących prywatności skontaktuj się z nami poprzez formularz kontaktowy.</p>
+        <p portal-text="Info_Privacy_Text1"></p>
+        <p portal-text="Info_Privacy_Text2"></p>
     </div>
 </section>

--- a/Portal/Views/Info/Returns.cshtml
+++ b/Portal/Views/Info/Returns.cshtml
@@ -12,7 +12,7 @@
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">
     <div class="max-w-3xl mx-auto text-gray-700 space-y-4">
-        <p>Masz 14 dni na zwrot towaru bez podania przyczyny. Reklamacje rozpatrujemy w ciągu 14 dni od ich otrzymania.</p>
-        <p>Aby rozpocząć proces zwrotu lub reklamacji, napisz na <strong>reklamacje@ciuchy.pl</strong>.</p>
+        <p portal-text="Info_Returns_Text1"></p>
+        <p portal-text="Info_Returns_Text2"></p>
     </div>
 </section>

--- a/Portal/Views/Info/Shipping.cshtml
+++ b/Portal/Views/Info/Shipping.cshtml
@@ -12,7 +12,7 @@
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">
     <div class="max-w-3xl mx-auto text-gray-700 space-y-4">
-        <p>Zamówienia realizujemy w ciągu 1-2 dni roboczych. Dostawy obsługuje firma kurierska oraz paczkomaty.</p>
-        <p>Akceptujemy płatności przelewem, kartą oraz za pobraniem. Szczegóły wyświetlane są na etapie finalizacji zamówienia.</p>
+        <p portal-text="Info_Shipping_Text1"></p>
+        <p portal-text="Info_Shipping_Text2"></p>
     </div>
 </section>

--- a/Portal/Views/Info/Terms.cshtml
+++ b/Portal/Views/Info/Terms.cshtml
@@ -12,7 +12,7 @@
 </div>
 <section class="py-16 px-6 md:px-12 lg:px-24 bg-white relative z-10">
     <div class="max-w-3xl mx-auto text-gray-700 space-y-4">
-        <p>Niniejszy regulamin określa zasady korzystania ze sklepu CIUCHY. Dokonując zakupu, akceptujesz poniższe warunki.</p>
-        <p>Pełną wersję regulaminu znajdziesz w dokumentach dostępnych w naszym biurze obsługi klienta.</p>
+        <p portal-text="Info_Terms_Text1"></p>
+        <p portal-text="Info_Terms_Text2"></p>
     </div>
 </section>

--- a/Portal/Views/Shared/_Layout.cshtml
+++ b/Portal/Views/Shared/_Layout.cshtml
@@ -12,7 +12,6 @@
 
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
 
-    <!-- Tailwind (CDN) -->
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
         tailwind.config = {
@@ -24,13 +23,11 @@
         }
     </script>
 
-    <!-- Montserrat font -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">
 </head>
 <body class="font-sans antialiased text-black">
-    <!-- ────────────── HEADER ────────────── -->
     <header id="main-header" class="fixed top-0 left-0 right-0 z-50 transition-all duration-300">
         <div class="container mx-auto px-6 md:px-12 lg:px-24">
             <div class="flex items-center justify-between py-6">
@@ -63,7 +60,6 @@
                         </svg>
                     </a>
 
-                    <!-- Mobile menu button -->
                     <button id="mobile-menu-button" class="md:hidden">
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 6h16M4 12h16M4 18h16" />
@@ -73,7 +69,6 @@
             </div>
         </div>
 
-        <!-- ────────────── MOBILE MENU ────────────── -->
         <div id="mobile-menu" class="md:hidden hidden bg-white absolute top-full left-0 right-0 shadow-lg">
             <div class="container mx-auto px-6 py-6">
                 <nav class="flex flex-col space-y-4">
@@ -86,7 +81,6 @@
         </div>
     </header>
 
-    <!-- ────────────── SEARCH OVERLAY ────────────── -->
     <div id="search-overlay" class="hidden fixed inset-0 bg-black/50 flex items-start justify-center overflow-auto z-50">
         <div class="bg-white p-6 mt-20 rounded shadow-md w-full max-w-lg mx-4">
             <form id="search-form" method="get" action="/Search" class="space-y-4">
@@ -119,22 +113,17 @@
         </div>
     </div>
 
-    <!-- ────────────── MAIN CONTENT ────────────── -->
     <main>@RenderBody()</main>
 
-    <!-- ────────────── FOOTER ────────────── -->
     <footer class="bg-black text-white py-16 px-6 md:px-12 lg:px-24">
         <div class="max-w-7xl mx-auto">
-            <!-- górna część -->
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12">
-                <!-- O nas -->
                 <div>
                     <h3 class="text-xl font-medium mb-6">O NAS</h3>
                     <p class="text-white/70 mb-6">
                         CIUCHY to awangardowa marka odzieżowa, która łączy nowoczesny design z najwyższą jakością wykonania.
                     </p>
                     <div class="flex space-x-4">
-                        <!-- Instagram -->
                         <a href="#" class="text-white hover:text-gray-300 transition-colors">
                             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
                                 <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zM12 0C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.053.014 8.333 0 8.741 0 12c0 3.259.014 3.667.072 4.947.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.667.014 15.259 0 12 0z"/>
@@ -142,13 +131,11 @@
                                 <circle cx="18.406" cy="5.594" r="1.44"/>
                             </svg>
                         </a>
-                        <!-- Facebook -->
                         <a href="#" class="text-white hover:text-gray-300 transition-colors">
                             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
                                 <path d="M22.675 0h-21.35C.592 0 0 .592 0 1.325v21.351C0 23.408.592 24 1.325 24H12.82v-9.294h-3.128v-3.622h3.128V8.413c0-3.1 1.893-4.788 4.659-4.788 1.325 0 2.463.099 2.795.143v3.24l-1.918.001c-1.504 0-1.795.715-1.795 1.763v2.313h3.587l-.467 3.622h-3.12V24h6.116c.73 0 1.323-.592 1.323-1.324V1.325C24 .592 23.408 0 22.675 0z"/>
                             </svg>
                         </a>
-                        <!-- Twitter -->
                         <a href="#" class="text-white hover:text-gray-300 transition-colors">
                             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
                                 <path d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045C7.91 8.744 4.282 6.784 1.853 3.805c-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.6 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z"/>
@@ -157,7 +144,6 @@
                     </div>
                 </div>
 
-                <!-- Informacje -->
                 <div>
                     <h3 class="text-xl font-medium mb-6">INFORMACJE</h3>
                     <ul class="space-y-3">
@@ -169,7 +155,6 @@
                     </ul>
                 </div>
 
-                <!-- Obsługa klienta -->
                 <div>
                     <h3 class="text-xl font-medium mb-6">OBSŁUGA KLIENTA</h3>
                     <ul class="space-y-3">
@@ -179,7 +164,6 @@
                     </ul>
                 </div>
 
-                <!-- Kontakt -->
                 <div>
                     <h3 class="text-xl font-medium mb-6">KONTAKT</h3>
                     <ul class="space-y-3">
@@ -206,7 +190,6 @@
                 </div>
             </div>
 
-            <!-- dolna część -->
             <div class="mt-16 pt-8 border-t border-white/20 flex flex-col md:flex-row md:justify-between md:items-center">
                 <div class="text-white/50 text-sm mb-4 md:mb-0">
                     &copy; 2025 CIUCHY. Wszystkie prawa zastrzeżone.
@@ -221,7 +204,6 @@
         </div>
     </footer>
 
-    <!-- Scripts -->
     <script src="~/js/site.js" asp-append-version="true"></script>
     <script>
         /* mobile menu & header shadow */

--- a/Portal/wwwroot/js/site.js
+++ b/Portal/wwwroot/js/site.js
@@ -1,18 +1,14 @@
-/* ────────────── PARALLAX & SCROLL ANIMATIONS ────────────── */
 function handleParallax() {
     const scrollPosition = window.pageYOffset;
 
-    // Hero (główne zdjęcie)
     const heroImage = document.querySelector('.hero-image');
     if (heroImage)
         heroImage.style.transform = `scale(1.1) translateY(${scrollPosition * 0.1}px)`;
 
-    // Lookbook tło
     const lookbookBg = document.querySelector('#lookbook .bg-fixed');
     if (lookbookBg)
         lookbookBg.style.backgroundPositionY = `${-scrollPosition * 0.2}px`;
 
-    // Fade-in elementów
     document.querySelectorAll('.product-card, .category-card').forEach((el) => {
         const elementPosition = el.getBoundingClientRect().top;
         const windowHeight    = window.innerHeight;
@@ -24,11 +20,9 @@ function handleParallax() {
 
 window.addEventListener('scroll', handleParallax);
 
-/* ────────────── DOMContentLoaded ────────────── */
 document.addEventListener('DOMContentLoaded', () => {
     handleParallax();
 
-    /* Smooth-scroll kotwic */
     document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
         anchor.addEventListener('click', (e) => {
             e.preventDefault();
@@ -39,7 +33,6 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
-    /* Dodawanie do koszyka */
     document.querySelectorAll('.add-to-cart-btn').forEach((btn) => {
         btn.addEventListener('click', async (e) => {
             e.preventDefault();
@@ -56,20 +49,17 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
-    /* ────────────── SEARCH OVERLAY ────────────── */
     const searchIcon  = document.getElementById('search-icon');
     const overlay     = document.getElementById('search-overlay');
     const searchInput = overlay ? overlay.querySelector('input[name="q"]') : null;
 
     if (searchIcon && overlay && searchInput) {
-        // otwarcie
         searchIcon.addEventListener('click', (e) => {
             e.preventDefault();
             overlay.classList.remove('hidden');
             searchInput.focus();
         });
 
-        // zamknięcie kliknięciem tła lub klawiszem ESC
         overlay.addEventListener('click', (e) => {
             if (e.target === overlay) overlay.classList.add('hidden');
         });

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# Portal Intranet
+
+Po zaktualizowaniu aplikacji uruchom skrypt `sql/UpdateHomeTextSections.sql`, aby ustawić sekcje `Home` i `Layout` dla istniejących wpisów w tabeli `PortalTexts`.
+Następnie wykonaj `sql/InsertPortalTexts.sql`, aby dodać brakujące teksty (m.in. akapity stron informacyjnych).

--- a/sql/InsertPortalTexts.sql
+++ b/sql/InsertPortalTexts.sql
@@ -1,5 +1,22 @@
 /* Inserts initial portal texts used across the entire site */
 
+-- Layout texts
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Header_Brand')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Header_Brand', 'CIUCHY', 'Layout');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Nav_Women')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Nav_Women', 'KOBIETY', 'Layout');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Nav_Men')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Nav_Men', 'MĘŻCZYŹNI', 'Layout');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Nav_Kids')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Nav_Kids', 'DZIECI', 'Layout');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Nav_Accessories')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Nav_Accessories', 'AKCESORIA', 'Layout');
+
 -- Category pages
 IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Category_Women_Title')
     INSERT INTO PortalTexts([Key], [Value], [Section])
@@ -59,6 +76,55 @@ IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Faq_HeroTitle')
 IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Contact_HeroTitle')
     INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Info_Contact_HeroTitle', 'KONTAKT', 'Info');
 
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_About_Text1')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_About_Text1', 'CIUCHY to marka łącząca pasję do mody z wysoką jakością wykonania. Tworzymy ubrania, które pozwalają wyrazić indywidualny styl.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_About_Text2')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_About_Text2', 'Nasz zespół dba o każdy detal, dzięki czemu oferujemy kolekcje dopracowane i zgodne z najnowszymi trendami.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Jobs_Text1')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Jobs_Text1', 'Szukasz inspirującego miejsca pracy? W CIUCHY stawiamy na kreatywność i rozwój. Regularnie poszukujemy osób pełnych pasji do mody.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Jobs_Text2')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Jobs_Text2', 'Wyślij swoje CV na adres <strong>praca@ciuchy.pl</strong> i dołącz do naszego zespołu.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Privacy_Text1')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Privacy_Text1', 'Chronimy Twoje dane osobowe i przetwarzamy je zgodnie z obowiązującymi przepisami. Szczegóły dotyczące przetwarzania danych znajdziesz poniżej.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Privacy_Text2')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Privacy_Text2', 'W razie pytań dotyczących prywatności skontaktuj się z nami poprzez formularz kontaktowy.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Shipping_Text1')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Shipping_Text1', 'Zamówienia realizujemy w ciągu 1-2 dni roboczych. Dostawy obsługuje firma kurierska oraz paczkomaty.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Shipping_Text2')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Shipping_Text2', 'Akceptujemy płatności przelewem, kartą oraz za pobraniem. Szczegóły wyświetlane są na etapie finalizacji zamówienia.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Terms_Text1')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Terms_Text1', 'Niniejszy regulamin określa zasady korzystania ze sklepu CIUCHY. Dokonując zakupu, akceptujesz poniższe warunki.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Terms_Text2')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Terms_Text2', 'Pełną wersję regulaminu znajdziesz w dokumentach dostępnych w naszym biurze obsługi klienta.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Returns_Text1')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Returns_Text1', 'Masz 14 dni na zwrot towaru bez podania przyczyny. Reklamacje rozpatrujemy w ciągu 14 dni od ich otrzymania.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Returns_Text2')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Returns_Text2', 'Aby rozpocząć proces zwrotu lub reklamacji, napisz na <strong>reklamacje@ciuchy.pl</strong>.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Faq_Text1')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Faq_Text1', 'Najczęściej zadawane pytania dotyczące zakupów w naszym sklepie znajdziesz poniżej.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Faq_Text2')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Faq_Text2', 'Jeśli nie znalazłeś odpowiedzi, napisz do nas – chętnie pomożemy.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Contact_Text1')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Contact_Text1', 'Masz pytania? Skontaktuj się z nami pod adresem <strong>kontakt@ciuchy.pl</strong> lub telefonicznie: <strong>+48 123 456 789</strong>.', 'Info');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Info_Contact_Text2')
+    INSERT INTO PortalTexts([Key], [Value], [Section])
+    VALUES ('Info_Contact_Text2', 'Odpowiadamy na wiadomości w dni robocze w godzinach 9:00-17:00.', 'Info');
+
 -- Account/Login
 IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Account_Login_Title')
     INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Account_Login_Title', 'Logowanie', 'Account');
@@ -68,4 +134,42 @@ IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Account_Login_Password')
     INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Account_Login_Password', 'Hasło', 'Account');
 IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Account_Login_Button')
     INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Account_Login_Button', 'Zaloguj', 'Account');
+
+-- Home page
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_HeroTop')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_HeroTop', 'NOWA KOLEKCJA', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_HeroBottom')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_HeroBottom', 'WIOSNA/LATO', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_HeroSubtitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_HeroSubtitle', 'Najmodniejsze trendy tego sezonu', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_HeroButton')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_HeroButton', 'ODKRYJ KOLEKCJĘ', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_CategoriesTitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_CategoriesTitle', 'KATEGORIE', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_CategoriesSubtitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_CategoriesSubtitle', 'Odkryj nasze sekcje i znajdź coś dla siebie', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_FeaturedTitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_FeaturedTitle', 'WYRÓŻNIONE PRODUKTY', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_FeaturedSubtitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_FeaturedSubtitle', 'Sprawdź nasze bestsellery', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_ShowMore')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_ShowMore', 'POKAŻ WIĘCEJ', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_LookbookTitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_LookbookTitle', 'LOOKBOOK', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_LookbookSubtitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_LookbookSubtitle', 'Zainspiruj się naszymi stylizacjami', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_LookbookButton')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_LookbookButton', 'POKAŻ LOOKBOOK', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_NewsletterTitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_NewsletterTitle', 'NEWSLETTER', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_NewsletterSubtitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_NewsletterSubtitle', 'Zapisz się, aby otrzymywać najnowsze informacje i oferty', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_NewsletterPlaceholder')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_NewsletterPlaceholder', 'Wpisz swój email', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_NewsletterButton')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_NewsletterButton', 'ZAPISZ SIĘ', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_InstagramTitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_InstagramTitle', 'INSTAGRAM', 'Home');
+IF NOT EXISTS (SELECT 1 FROM PortalTexts WHERE [Key] = 'Home_InstagramSubtitle')
+    INSERT INTO PortalTexts([Key], [Value], [Section]) VALUES ('Home_InstagramSubtitle', 'Obserwuj nas na Instagramie', 'Home');
 GO

--- a/sql/UpdateHomeTextSections.sql
+++ b/sql/UpdateHomeTextSections.sql
@@ -1,0 +1,17 @@
+-- Assigns Home section to existing portal texts whose keys begin with Home_
+-- and have no section set
+UPDATE PortalTexts
+SET Section = 'Home'
+WHERE [Key] LIKE 'Home_%' AND (Section IS NULL OR Section = '');
+
+-- Assign Layout section to navigation and header texts that lack it
+UPDATE PortalTexts
+SET Section = 'Layout'
+WHERE [Key] IN ('Header_Brand', 'Nav_Women', 'Nav_Men', 'Nav_Kids', 'Nav_Accessories')
+  AND (Section IS NULL OR Section = '');
+
+-- Assign Info section to texts related to info pages
+UPDATE PortalTexts
+SET Section = 'Info'
+WHERE [Key] LIKE 'Info_%' AND (Section IS NULL OR Section = '');
+GO


### PR DESCRIPTION
## Summary
- make PortalTextTagHelper allow HTML content
- seed paragraph texts for info pages
- map all info page paragraphs to portal texts
- ensure UpdateHomeTextSections handles info pages
- mention running InsertPortalTexts.sql
- remove comments from source files and JS
- translate the error page to Polish

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68457ccb4e8883309fbed9d1cdc0a08e